### PR TITLE
APIMF-1777: DialectDomainElementModel only returns distint fields

### DIFF
--- a/shared/src/main/scala/amf/plugins/document/vocabularies/metamodel/domain/DialectDomainElementModel.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/metamodel/domain/DialectDomainElementModel.scala
@@ -15,7 +15,7 @@ class DialectDomainElementModel(val typeIri: Seq[String] = Seq(),
 
 
   override val fields: List[Field] =
-    DialectDomainElementModel.Abstract :: DialectDomainElementModel.DeclarationName :: DomainElementModel.fields ++ LinkableElementModel.fields ++ typeFields
+    (DialectDomainElementModel.Abstract :: DialectDomainElementModel.DeclarationName :: DomainElementModel.fields ++ LinkableElementModel.fields ++ typeFields).distinct
   override val `type`: List[ValueType] = typeIri
     .map(iriToValue)
     .toList ++ ((Namespace.Meta + "DialectDomainElement") :: DomainElementModel.`type`)


### PR DESCRIPTION
This PR is related to:
- https://github.com/mulesoft/amf/pull/217
- https://github.com/mulesoft/amf-core/pull/34

Should distinct fields always be returned from calling the _fields_ method on a Model? A way to easily fix this would be to drop DomainElementModel.fields but this will limit a change in DomainElementModel being propagated to DialectDomainElementModel fields