### PR TITLE
APIMF-2215: Add duplicate term validation in vocabularies parsing

### DIFF
--- a/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/ReferenceDeclarations.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/ReferenceDeclarations.scala
@@ -1,0 +1,30 @@
+package amf.plugins.document.vocabularies.parser.vocabularies
+import amf.core.model.document.BaseUnit
+import amf.plugins.document.vocabularies.model.document.Vocabulary
+import amf.plugins.document.vocabularies.model.domain.{ClassTerm, External, PropertyTerm}
+
+import scala.collection.mutable
+
+case class ReferenceDeclarations(references: mutable.Map[String, Any] = mutable.Map())(
+    implicit ctx: VocabularyContext) {
+  def +=(alias: String, unit: BaseUnit): Unit = {
+    references += (alias -> unit)
+    val library = ctx.declarations.getOrCreateLibrary(alias)
+    unit match {
+      case d: Vocabulary =>
+        ctx.registerVocabulary(alias, d)
+        d.declares.foreach {
+          case prop: PropertyTerm => library.registerTerm(prop)
+          case cls: ClassTerm     => library.registerTerm(cls)
+        }
+    }
+  }
+
+  def +=(external: External): Unit = {
+    references += (external.alias.value()                 -> external)
+    ctx.declarations.externals += (external.alias.value() -> external)
+  }
+
+  def baseUnitReferences(): Seq[BaseUnit] =
+    references.values.toSet.filter(_.isInstanceOf[BaseUnit]).toSeq.asInstanceOf[Seq[BaseUnit]]
+}

--- a/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesParser.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesParser.scala
@@ -1,307 +1,15 @@
 package amf.plugins.document.vocabularies.parser.vocabularies
 
 import amf.core.Root
-import amf.core.annotations.Aliases
-import amf.core.errorhandling.ErrorHandler
 import amf.core.model.DataType
-import amf.core.model.document.{BaseUnit, DeclaresModel}
-import amf.core.model.domain.DomainElement
-import amf.core.parser.{BaseSpecParser, ParserContext, _}
+import amf.core.model.document.BaseUnit
+import amf.core.parser.{BaseSpecParser, _}
 import amf.core.vocabulary.Namespace
 import amf.plugins.document.vocabularies.metamodel.document.VocabularyModel
 import amf.plugins.document.vocabularies.metamodel.domain.{ClassTermModel, ObjectPropertyTermModel}
 import amf.plugins.document.vocabularies.model.document.Vocabulary
 import amf.plugins.document.vocabularies.model.domain._
-import amf.plugins.document.vocabularies.parser.common.SyntaxErrorReporter
-import amf.validation.DialectValidations.ExpectedVocabularyModule
 import org.yaml.model._
-
-import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
-
-class VocabularyDeclarations(var externals: Map[String, External] = Map(),
-                             var classTerms: Map[String, ClassTerm] = Map(),
-                             var propertyTerms: Map[String, PropertyTerm] = Map(),
-                             var usedVocabs: Map[String, Vocabulary] = Map(),
-                             libs: Map[String, VocabularyDeclarations] = Map(),
-                             errorHandler: ErrorHandler,
-                             futureDeclarations: FutureDeclarations)
-    extends Declarations(libs, Map(), Map(), errorHandler, futureDeclarations) {
-
-  def registerTerm(term: PropertyTerm): Unit = {
-    if (!term.name.value().contains(".")) {
-      propertyTerms += (term.name.value() -> term)
-    }
-  }
-
-  def registerTerm(term: ClassTerm): Unit = {
-    if (!term.name.value().contains(".")) {
-      classTerms += (term.name.value() -> term)
-    }
-  }
-
-  def registerUsedVocabulary(alias: String, vocab: Vocabulary): Unit = usedVocabs += (alias -> vocab)
-
-  /** Get or create specified library. */
-  override def getOrCreateLibrary(alias: String): VocabularyDeclarations = {
-    libraries.get(alias) match {
-      case Some(lib: VocabularyDeclarations) => lib
-      case _ =>
-        val result =
-          new VocabularyDeclarations(errorHandler = errorHandler, futureDeclarations = EmptyFutureDeclarations())
-        libraries = libraries + (alias -> result)
-        result
-    }
-  }
-
-  def getTermId(value: String): Option[String] = getPropertyTermId(value).orElse(getClassTermId(value))
-
-  def getPropertyTermId(alias: String): Option[String] = {
-    propertyTerms.get(alias) match {
-      case Some(pt) => Some(pt.id)
-      case None     => None
-    }
-  }
-
-  def getClassTermId(alias: String): Option[String] = {
-    classTerms.get(alias) match {
-      case Some(ct) => Some(ct.id)
-      case None     => None
-    }
-  }
-
-  def resolveExternal(key: String): Option[String] = {
-    if (key.contains(".")) {
-      val prefix = key.split("\\.").head
-      val value  = key.split("\\.").last
-      externals.get(prefix).map(external => s"${external.base.value()}$value")
-    }
-    else {
-      None
-    }
-  }
-
-  def resolveExternalNamespace(prefix: Option[String], suffix: String): Try[String] = {
-    prefix match {
-      case Some(prefixString) =>
-        resolveExternal(s"$prefixString.$suffix") match {
-          case Some(resolvedPrefix) => Success(resolvedPrefix)
-          case _                    => Failure(new Exception(s"Cannot resolve external prefix $prefixString"))
-        }
-      case _ => Success((Namespace.Data + suffix).iri())
-    }
-  }
-}
-
-trait VocabularySyntax { this: VocabularyContext =>
-
-  val vocabulary: Map[String, String] = Map(
-      "$dialect"      -> "string",
-      "base"          -> "string",
-      "usage"         -> "string",
-      "vocabulary"    -> "string",
-      "uses"          -> "libraries",
-      "external"      -> "libraries",
-      "classTerms"    -> "ClassTerm[]",
-      "propertyTerms" -> "PropertyTerm[]"
-  )
-
-  val classTerm: Map[String, String] = Map(
-      "displayName" -> "string",
-      "description" -> "string",
-      "properties"  -> "string[]",
-      "extends"     -> "string[]"
-  )
-
-  val propertyTerm: Map[String, String] = Map(
-      "displayName" -> "string",
-      "description" -> "string",
-      "range"       -> "string[]",
-      "extends"     -> "string[]"
-  )
-
-  def closedNode(nodeType: String, id: String, map: YMap): Unit = {
-    val allowedProps = nodeType match {
-      case "vocabulary"   => vocabulary
-      case "classTerm"    => classTerm
-      case "propertyTerm" => propertyTerm
-    }
-    map.map.keySet.map(_.as[YScalar].text).foreach { property =>
-      allowedProps.get(property) match {
-        case Some(_) => // correct
-        case None    => closedNodeViolation(id, property, nodeType, map)
-      }
-    }
-  }
-}
-
-class VocabularyContext(private val wrapped: ParserContext, private val ds: Option[VocabularyDeclarations] = None)
-    extends ParserContext(wrapped.rootContextDocument, wrapped.refs, wrapped.futureDeclarations, wrapped.eh)
-    with VocabularySyntax
-    with SyntaxErrorReporter {
-
-  var imported: Map[String, Vocabulary] = Map()
-
-  def registerVocabulary(alias: String, vocabulary: Vocabulary) = {
-    imported += (alias -> vocabulary)
-  }
-
-  var pendingLocal: Seq[(String, String, YPart, Boolean)] = Nil
-
-  def register(alias: String, classTerm: ClassTerm): Unit = {
-    pendingLocal = pendingLocal.filter(_._1 != classTerm.id)
-    declarations.classTerms += (alias -> classTerm)
-  }
-
-  def register(alias: String, propertyTerm: PropertyTerm): Unit = {
-    pendingLocal = pendingLocal.filter(_._1 != propertyTerm.id)
-    declarations.propertyTerms += (alias -> propertyTerm)
-  }
-
-  def resolvePropertyTermAlias(base: String,
-                               propertyTermAlias: String,
-                               where: YPart,
-                               strictLocal: Boolean): Option[String] = {
-    if (propertyTermAlias.contains(".")) {
-      val prefix = propertyTermAlias.split("\\.").head
-      val value  = propertyTermAlias.split("\\.").last
-      declarations.externals.get(prefix) match {
-        case Some(external) => Some(s"${external.base.value()}$value")
-        case None =>
-          declarations.libraries.get(prefix) match {
-            case Some(vocab: VocabularyDeclarations) => vocab.getPropertyTermId(value)
-            case _                                   => None
-          }
-      }
-    }
-    else {
-      val local = s"$base$propertyTermAlias"
-      declarations.getPropertyTermId(propertyTermAlias) match {
-        case Some(_) => // ignore
-        case None    => if (strictLocal) { pendingLocal ++= Seq((local, propertyTermAlias, where, true)) }
-      }
-      Some(local)
-    }
-  }
-
-  def resolveClassTermAlias(base: String,
-                            classTermAlias: String,
-                            where: YPart,
-                            strictLocal: Boolean): Option[String] = {
-    if (classTermAlias.contains(".")) {
-      val prefix = classTermAlias.split("\\.").head
-      val value  = classTermAlias.split("\\.").last
-      declarations.externals.get(prefix) match {
-        case Some(external) => Some(s"${external.base.value()}$value")
-        case None =>
-          declarations.libraries.get(prefix) match {
-            case Some(vocab: VocabularyDeclarations) => vocab.getClassTermId(value)
-            case _                                   => None
-          }
-      }
-    }
-    else {
-      val local = s"$base$classTermAlias"
-      declarations.getClassTermId(classTermAlias) match {
-        case Some(_) => // ignore
-        case None    => if (strictLocal) { pendingLocal ++= Seq((local, classTermAlias, where, false)) }
-      }
-      Some(local)
-    }
-  }
-
-  val declarations: VocabularyDeclarations =
-    ds.getOrElse(new VocabularyDeclarations(errorHandler = eh, futureDeclarations = futureDeclarations))
-
-  def terms(): Seq[DomainElement] = declarations.classTerms.values.toSeq ++ declarations.propertyTerms.values.toSeq
-}
-
-case class ReferenceDeclarations(references: mutable.Map[String, Any] = mutable.Map())(
-    implicit ctx: VocabularyContext) {
-  def +=(alias: String, unit: BaseUnit): Unit = {
-    references += (alias -> unit)
-    val library = ctx.declarations.getOrCreateLibrary(alias)
-    unit match {
-      case d: Vocabulary =>
-        ctx.registerVocabulary(alias, d)
-        d.declares.foreach {
-          case prop: PropertyTerm => library.registerTerm(prop)
-          case cls: ClassTerm     => library.registerTerm(cls)
-        }
-    }
-  }
-
-  def +=(external: External): Unit = {
-    references += (external.alias.value()                 -> external)
-    ctx.declarations.externals += (external.alias.value() -> external)
-  }
-
-  def baseUnitReferences(): Seq[BaseUnit] =
-    references.values.toSet.filter(_.isInstanceOf[BaseUnit]).toSeq.asInstanceOf[Seq[BaseUnit]]
-}
-
-case class VocabulariesReferencesParser(map: YMap, references: Seq[ParsedReference])(implicit ctx: VocabularyContext) {
-
-  def parse(location: String): ReferenceDeclarations = {
-    val result = ReferenceDeclarations()
-    parseLibraries(result, location)
-    parseExternals(result, location)
-    result
-  }
-
-  private def target(url: String): Option[BaseUnit] =
-    references.find(r => r.origin.url.equals(url)).map(_.unit)
-
-  private def parseLibraries(result: ReferenceDeclarations, id: String): Unit = {
-    map.key(
-        "uses",
-        entry =>
-          entry.value
-            .as[YMap]
-            .entries
-            .foreach(
-                e => {
-                  val alias: String = e.key.as[YScalar].text
-                  val url: String   = e.value.as[YScalar].text
-                  target(url)
-                    .foreach {
-                      case module: DeclaresModel => result += (alias, collectAlias(module, alias -> (module.id, url)))
-                      case other =>
-                        ctx.eh.violation(ExpectedVocabularyModule,
-                                         id,
-                                         s"Expected vocabulary module but found: $other",
-                                         e) // todo Uses should only reference modules...
-                    }
-                })
-    )
-  }
-
-  private def parseExternals(result: ReferenceDeclarations, id: String): Unit = {
-    map.key(
-        "external",
-        entry =>
-          entry.value
-            .as[YMap]
-            .entries
-            .foreach(e => {
-              val alias: String = e.key.as[YScalar].text
-              val base: String  = e.value.as[YScalar].text
-              val external      = External()
-              result += external.withAlias(alias).withBase(base)
-            })
-    )
-  }
-
-  private def collectAlias(module: BaseUnit,
-                           alias: (Aliases.Alias, (Aliases.FullUrl, Aliases.RelativeUrl))): BaseUnit = {
-    module.annotations.find(classOf[Aliases]) match {
-      case Some(aliases) =>
-        module.annotations.reject(_.isInstanceOf[Aliases])
-        module.add(aliases.copy(aliases = aliases.aliases + alias))
-      case None => module.add(Aliases(Set(alias)))
-    }
-  }
-}
 
 class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContext) extends BaseSpecParser {
 
@@ -354,8 +62,7 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
       case (term, alias, location, isProperty) =>
         if (isProperty) {
           ctx.missingTermWarning(term, vocabulary.id, location)
-        }
-        else {
+        } else {
           ctx.missingTermViolation(term, vocabulary.id, location)
         }
     }
@@ -363,15 +70,15 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
     vocabulary
   }
 
-  def parseClassTerms(map: YMap) = {
+  def parseClassTerms(map: YMap): Unit = {
     map.key(
-        "classTerms",
-        entry => {
-          val classDeclarations = entry.value.as[YMap]
-          classDeclarations.entries.foreach { classTermDeclaration =>
-            parseClassTerm(classTermDeclaration)
-          }
+      "classTerms",
+      entry => {
+        val classDeclarations = entry.value.as[YMap]
+        classDeclarations.entries.foreach { classTermDeclaration =>
+          parseClassTerm(classTermDeclaration)
         }
+      }
     )
   }
 
@@ -402,72 +109,71 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
         })
 
         classTermMap.key(
-            "properties",
-            entry => {
-              val refs: Seq[String] = entry.value.tagType match {
-                case YType.Str => Seq(ValueNode(entry.value).string().toString)
-                case YType.Seq =>
-                  DefaultArrayNode(entry.value).nodes._1
-                    .map(_.value.toString) // ArrayNode(entry.value).strings().scalars.map(_.toString)
-              }
-
-              val properties: Seq[String] = refs
-                .map { term: String =>
-                  ctx.resolvePropertyTermAlias(vocabulary.base.value(), term, entry.value, strictLocal = true) match {
-                    case Some(v) => Some(v)
-                    case None =>
-                      ctx.missingTermViolation(term, vocabulary.id, entry.value)
-                      None
-                  }
-                }
-                .filter(_.nonEmpty)
-                .map(_.get)
-
-              if (properties.nonEmpty)
-                classTerm.set(ClassTermModel.Properties, properties)
+          "properties",
+          entry => {
+            val refs: Seq[String] = entry.value.tagType match {
+              case YType.Str => Seq(ValueNode(entry.value).string().toString)
+              case YType.Seq =>
+                DefaultArrayNode(entry.value).nodes._1
+                  .map(_.value.toString) // ArrayNode(entry.value).strings().scalars.map(_.toString)
             }
+
+            val properties: Seq[String] = refs
+              .map { term: String =>
+                ctx.resolvePropertyTermAlias(vocabulary.base.value(), term, entry.value, strictLocal = true) match {
+                  case Some(v) => Some(v)
+                  case None =>
+                    ctx.missingTermViolation(term, vocabulary.id, entry.value)
+                    None
+                }
+              }
+              .filter(_.nonEmpty)
+              .map(_.get)
+
+            if (properties.nonEmpty)
+              classTerm.set(ClassTermModel.Properties, properties)
+          }
         )
 
         classTermMap.key(
-            "extends",
-            entry => {
-              val refs: Seq[String] = entry.value.tagType match {
-                case YType.Str => Seq(ValueNode(entry.value).string().toString)
-                case YType.Seq => {
-                  // ArrayNode(entry.value).strings().scalars.map(_.toString)
-                  DefaultArrayNode(node = entry.value).nodes._1.map(_.value.toString)
+          "extends",
+          entry => {
+            val refs: Seq[String] = entry.value.tagType match {
+              case YType.Str => Seq(ValueNode(entry.value).string().toString)
+              case YType.Seq =>
+                // ArrayNode(entry.value).strings().scalars.map(_.toString)
+                DefaultArrayNode(node = entry.value).nodes._1.map(_.value.toString)
+            }
+
+            val superClasses: Seq[String] = refs
+              .map { term: String =>
+                ctx.resolveClassTermAlias(vocabulary.base.value(), term, entry.value, strictLocal = true) match {
+                  case Some(v) => Some(v)
+                  case None =>
+                    ctx.missingTermViolation(term, vocabulary.id, entry.value)
+                    None
                 }
               }
+              .filter(_.nonEmpty)
+              .map(_.get)
 
-              val superClasses: Seq[String] = refs
-                .map { term: String =>
-                  ctx.resolveClassTermAlias(vocabulary.base.value(), term, entry.value, strictLocal = true) match {
-                    case Some(v) => Some(v)
-                    case None =>
-                      ctx.missingTermViolation(term, vocabulary.id, entry.value)
-                      None
-                  }
-                }
-                .filter(_.nonEmpty)
-                .map(_.get)
-
-              classTerm.set(ClassTermModel.SubClassOf, superClasses)
-            }
+            classTerm.set(ClassTermModel.SubClassOf, superClasses)
+          }
         )
     }
 
     ctx.register(classTermAlias, classTerm)
   }
 
-  def parsePropertyTerms(map: YMap) = {
+  def parsePropertyTerms(map: YMap): Unit = {
     map.key(
-        "propertyTerms",
-        entry => {
-          val classDeclarations = entry.value.as[YMap]
-          classDeclarations.entries.foreach { propertyTermDeclaration =>
-            parsePropertyTerm(propertyTermDeclaration)
-          }
+      "propertyTerms",
+      entry => {
+        val classDeclarations = entry.value.as[YMap]
+        classDeclarations.entries.foreach { propertyTermDeclaration =>
+          parsePropertyTerm(propertyTermDeclaration)
         }
+      }
     )
   }
 
@@ -515,56 +221,55 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
         })
 
         propertyTermMap.key(
-            "range",
-            entry => {
-              val text = entry.value.as[YScalar].text
-              val rangeId = text match {
-                case "guid" =>
-                  Some((Namespace.Shapes + "guid").iri())
-                case "any" | "uri" | "string" | "integer" | "float" | "double" | "long" | "boolean" | "time" | "date" |
-                    "dateTime" =>
-                  Some(DataType(text))
-                case classAlias =>
-                  ctx
-                    .resolveClassTermAlias(vocabulary.base.value(), classAlias, entry.value, strictLocal = true) match {
-                    case Some(classTermId) => Some(classTermId)
-                    case None =>
-                      ctx.missingTermViolation(classAlias, vocabulary.id, entry.value)
-                      None
-                  }
-              }
-
-              rangeId match {
-                case Some(id: String) => propertyTerm.withRange(id)
-                case None             => // ignore
-              }
+          "range",
+          entry => {
+            val text = entry.value.as[YScalar].text
+            val rangeId = text match {
+              case "guid" =>
+                Some((Namespace.Shapes + "guid").iri())
+              case "any" | "uri" | "string" | "integer" | "float" | "double" | "long" | "boolean" | "time" | "date" |
+                  "dateTime" =>
+                Some(DataType(text))
+              case classAlias =>
+                ctx.resolveClassTermAlias(vocabulary.base.value(), classAlias, entry.value, strictLocal = true) match {
+                  case Some(classTermId) => Some(classTermId)
+                  case None =>
+                    ctx.missingTermViolation(classAlias, vocabulary.id, entry.value)
+                    None
+                }
             }
+
+            rangeId match {
+              case Some(id: String) => propertyTerm.withRange(id)
+              case None             => // ignore
+            }
+          }
         )
 
         propertyTermMap.key(
-            "extends",
-            entry => {
-              val refs: Seq[String] = entry.value.tagType match {
-                case YType.Str => Seq(ValueNode(entry.value).string().toString)
-                case YType.Seq =>
-                  DefaultArrayNode(entry.value).nodes._1.map(_.as[YScalar].text)
-                // ArrayNode(entry.value).strings().scalars.map(_.toString)
-              }
-
-              val superClasses: Seq[String] = refs
-                .map { term: String =>
-                  ctx.resolvePropertyTermAlias(vocabulary.base.value(), term, entry.value, strictLocal = true) match {
-                    case Some(v) => Some(v)
-                    case None =>
-                      ctx.missingTermViolation(term, vocabulary.id, entry.value)
-                      None
-                  }
-                }
-                .filter(_.nonEmpty)
-                .map(_.get)
-
-              propertyTerm.set(ObjectPropertyTermModel.SubPropertyOf, superClasses)
+          "extends",
+          entry => {
+            val refs: Seq[String] = entry.value.tagType match {
+              case YType.Str => Seq(ValueNode(entry.value).string().toString)
+              case YType.Seq =>
+                DefaultArrayNode(entry.value).nodes._1.map(_.as[YScalar].text)
+              // ArrayNode(entry.value).strings().scalars.map(_.toString)
             }
+
+            val superClasses: Seq[String] = refs
+              .map { term: String =>
+                ctx.resolvePropertyTermAlias(vocabulary.base.value(), term, entry.value, strictLocal = true) match {
+                  case Some(v) => Some(v)
+                  case None =>
+                    ctx.missingTermViolation(term, vocabulary.id, entry.value)
+                    None
+                }
+              }
+              .filter(_.nonEmpty)
+              .map(_.get)
+
+            propertyTerm.set(ObjectPropertyTermModel.SubPropertyOf, superClasses)
+          }
         )
     }
 

--- a/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesReferencesParser.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesReferencesParser.scala
@@ -1,0 +1,67 @@
+package amf.plugins.document.vocabularies.parser.vocabularies
+import amf.core.annotations.Aliases
+import amf.core.model.document.{BaseUnit, DeclaresModel}
+import amf.core.parser.ParsedReference
+import amf.plugins.document.vocabularies.model.domain.External
+import amf.validation.DialectValidations.ExpectedVocabularyModule
+import org.yaml.model.{YMap, YScalar}
+import amf.plugins.document.vocabularies.parser.dialects.DialectAstOps.DialectYMapOps
+
+case class VocabulariesReferencesParser(map: YMap, references: Seq[ParsedReference])(implicit ctx: VocabularyContext) {
+
+  def parse(location: String): ReferenceDeclarations = {
+    val result = ReferenceDeclarations()
+    parseLibraries(result, location)
+    parseExternals(result, location)
+    result
+  }
+
+  private def target(url: String): Option[BaseUnit] =
+    references.find(r => r.origin.url.equals(url)).map(_.unit)
+
+  private def parseLibraries(result: ReferenceDeclarations, id: String): Unit = {
+    map.key(
+      "uses",
+      entry =>
+        entry.value
+          .as[YMap]
+          .entries
+          .foreach(e => {
+            val alias: String = e.key.as[YScalar].text
+            val url: String   = e.value.as[YScalar].text
+            target(url)
+              .foreach {
+                case module: DeclaresModel => result += (alias, collectAlias(module, alias -> (module.id, url)))
+                case other =>
+                  ctx.eh.violation(ExpectedVocabularyModule, id, s"Expected vocabulary module but found: $other", e) // todo Uses should only reference modules...
+              }
+          })
+    )
+  }
+
+  private def parseExternals(result: ReferenceDeclarations, id: String): Unit = {
+    map.key(
+      "external",
+      entry =>
+        entry.value
+          .as[YMap]
+          .entries
+          .foreach(e => {
+            val alias: String = e.key.as[YScalar].text
+            val base: String  = e.value.as[YScalar].text
+            val external      = External()
+            result += external.withAlias(alias).withBase(base)
+          })
+    )
+  }
+
+  private def collectAlias(module: BaseUnit,
+                           alias: (Aliases.Alias, (Aliases.FullUrl, Aliases.RelativeUrl))): BaseUnit = {
+    module.annotations.find(classOf[Aliases]) match {
+      case Some(aliases) =>
+        module.annotations.reject(_.isInstanceOf[Aliases])
+        module.add(aliases.copy(aliases = aliases.aliases + alias))
+      case None => module.add(Aliases(Set(alias)))
+    }
+  }
+}

--- a/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabularyContext.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabularyContext.scala
@@ -1,0 +1,86 @@
+package amf.plugins.document.vocabularies.parser.vocabularies
+import amf.core.model.domain.DomainElement
+import amf.core.parser.ParserContext
+import amf.plugins.document.vocabularies.model.document.Vocabulary
+import amf.plugins.document.vocabularies.model.domain.{ClassTerm, PropertyTerm}
+import amf.plugins.document.vocabularies.parser.common.SyntaxErrorReporter
+import org.yaml.model.YPart
+
+class VocabularyContext(private val wrapped: ParserContext, private val ds: Option[VocabularyDeclarations] = None)
+    extends ParserContext(wrapped.rootContextDocument, wrapped.refs, wrapped.futureDeclarations, wrapped.eh)
+    with VocabularySyntax
+    with SyntaxErrorReporter {
+
+  var imported: Map[String, Vocabulary] = Map()
+
+  def registerVocabulary(alias: String, vocabulary: Vocabulary): Unit = {
+    imported += (alias -> vocabulary)
+  }
+
+  var pendingLocal: Seq[(String, String, YPart, Boolean)] = Nil
+
+  def register(alias: String, classTerm: ClassTerm): Unit = {
+    pendingLocal = pendingLocal.filter(_._1 != classTerm.id)
+    declarations.classTerms += (alias -> classTerm)
+  }
+
+  def register(alias: String, propertyTerm: PropertyTerm): Unit = {
+    pendingLocal = pendingLocal.filter(_._1 != propertyTerm.id)
+    declarations.propertyTerms += (alias -> propertyTerm)
+  }
+
+  def resolvePropertyTermAlias(base: String,
+                               propertyTermAlias: String,
+                               where: YPart,
+                               strictLocal: Boolean): Option[String] = {
+    if (propertyTermAlias.contains(".")) {
+      val prefix = propertyTermAlias.split("\\.").head
+      val value  = propertyTermAlias.split("\\.").last
+      declarations.externals.get(prefix) match {
+        case Some(external) => Some(s"${external.base.value()}$value")
+        case None =>
+          declarations.libraries.get(prefix) match {
+            case Some(vocab: VocabularyDeclarations) => vocab.getPropertyTermId(value)
+            case _                                   => None
+          }
+      }
+    } else {
+      val local = s"$base$propertyTermAlias"
+      declarations.getPropertyTermId(propertyTermAlias) match {
+        case Some(_) => // ignore
+        case None    => if (strictLocal) { pendingLocal ++= Seq((local, propertyTermAlias, where, true)) }
+      }
+      Some(local)
+    }
+  }
+
+  def resolveClassTermAlias(base: String,
+                            classTermAlias: String,
+                            where: YPart,
+                            strictLocal: Boolean): Option[String] = {
+    if (classTermAlias.contains(".")) {
+      val prefix = classTermAlias.split("\\.").head
+      val value  = classTermAlias.split("\\.").last
+      declarations.externals.get(prefix) match {
+        case Some(external) => Some(s"${external.base.value()}$value")
+        case None =>
+          declarations.libraries.get(prefix) match {
+            case Some(vocab: VocabularyDeclarations) => vocab.getClassTermId(value)
+            case _                                   => None
+          }
+      }
+    } else {
+      val local = s"$base$classTermAlias"
+      declarations.getClassTermId(classTermAlias) match {
+        case Some(_) => // ignore
+        case None    => if (strictLocal) { pendingLocal ++= Seq((local, classTermAlias, where, false)) }
+      }
+      Some(local)
+    }
+  }
+
+  val declarations: VocabularyDeclarations =
+    ds.getOrElse(new VocabularyDeclarations(errorHandler = eh, futureDeclarations = futureDeclarations))
+
+  def terms(): Seq[DomainElement] = declarations.classTerms.values.toSeq ++ declarations.propertyTerms.values.toSeq
+}

--- a/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabularyDeclarations.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabularyDeclarations.scala
@@ -1,0 +1,81 @@
+package amf.plugins.document.vocabularies.parser.vocabularies
+import amf.core.errorhandling.ErrorHandler
+import amf.core.parser.{Declarations, EmptyFutureDeclarations, FutureDeclarations}
+import amf.core.vocabulary.Namespace
+import amf.plugins.document.vocabularies.model.document.Vocabulary
+import amf.plugins.document.vocabularies.model.domain.{ClassTerm, External, PropertyTerm}
+
+import scala.util.{Failure, Success, Try}
+
+class VocabularyDeclarations(var externals: Map[String, External] = Map(),
+                             var classTerms: Map[String, ClassTerm] = Map(),
+                             var propertyTerms: Map[String, PropertyTerm] = Map(),
+                             var usedVocabs: Map[String, Vocabulary] = Map(),
+                             libs: Map[String, VocabularyDeclarations] = Map(),
+                             errorHandler: ErrorHandler,
+                             futureDeclarations: FutureDeclarations)
+    extends Declarations(libs, Map(), Map(), errorHandler, futureDeclarations) {
+
+  def registerTerm(term: PropertyTerm): Unit = {
+    if (!term.name.value().contains(".")) {
+      propertyTerms += (term.name.value() -> term)
+    }
+  }
+
+  def registerTerm(term: ClassTerm): Unit = {
+    if (!term.name.value().contains(".")) {
+      classTerms += (term.name.value() -> term)
+    }
+  }
+
+  def registerUsedVocabulary(alias: String, vocab: Vocabulary): Unit = usedVocabs += (alias -> vocab)
+
+  /** Get or create specified library. */
+  override def getOrCreateLibrary(alias: String): VocabularyDeclarations = {
+    libraries.get(alias) match {
+      case Some(lib: VocabularyDeclarations) => lib
+      case _ =>
+        val result =
+          new VocabularyDeclarations(errorHandler = errorHandler, futureDeclarations = EmptyFutureDeclarations())
+        libraries = libraries + (alias -> result)
+        result
+    }
+  }
+
+  def getTermId(value: String): Option[String] = getPropertyTermId(value).orElse(getClassTermId(value))
+
+  def getPropertyTermId(alias: String): Option[String] = {
+    propertyTerms.get(alias) match {
+      case Some(pt) => Some(pt.id)
+      case None     => None
+    }
+  }
+
+  def getClassTermId(alias: String): Option[String] = {
+    classTerms.get(alias) match {
+      case Some(ct) => Some(ct.id)
+      case None     => None
+    }
+  }
+
+  def resolveExternal(key: String): Option[String] = {
+    if (key.contains(".")) {
+      val prefix = key.split("\\.").head
+      val value  = key.split("\\.").last
+      externals.get(prefix).map(external => s"${external.base.value()}$value")
+    } else {
+      None
+    }
+  }
+
+  def resolveExternalNamespace(prefix: Option[String], suffix: String): Try[String] = {
+    prefix match {
+      case Some(prefixString) =>
+        resolveExternal(s"$prefixString.$suffix") match {
+          case Some(resolvedPrefix) => Success(resolvedPrefix)
+          case _                    => Failure(new Exception(s"Cannot resolve external prefix $prefixString"))
+        }
+      case _ => Success((Namespace.Data + suffix).iri())
+    }
+  }
+}

--- a/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabularySyntax.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabularySyntax.scala
@@ -1,0 +1,44 @@
+package amf.plugins.document.vocabularies.parser.vocabularies
+import org.yaml.model.{YMap, YScalar}
+
+trait VocabularySyntax { this: VocabularyContext =>
+
+  val vocabulary: Map[String, String] = Map(
+    "$dialect"      -> "string",
+    "base"          -> "string",
+    "usage"         -> "string",
+    "vocabulary"    -> "string",
+    "uses"          -> "libraries",
+    "external"      -> "libraries",
+    "classTerms"    -> "ClassTerm[]",
+    "propertyTerms" -> "PropertyTerm[]"
+  )
+
+  val classTerm: Map[String, String] = Map(
+    "displayName" -> "string",
+    "description" -> "string",
+    "properties"  -> "string[]",
+    "extends"     -> "string[]"
+  )
+
+  val propertyTerm: Map[String, String] = Map(
+    "displayName" -> "string",
+    "description" -> "string",
+    "range"       -> "string[]",
+    "extends"     -> "string[]"
+  )
+
+  def closedNode(nodeType: String, id: String, map: YMap): Unit = {
+    val allowedProps = nodeType match {
+      case "vocabulary"   => vocabulary
+      case "classTerm"    => classTerm
+      case "propertyTerm" => propertyTerm
+    }
+    map.map.keySet.map(_.as[YScalar].text).foreach { property =>
+      allowedProps.get(property) match {
+        case Some(_) => // correct
+        case None    => closedNodeViolation(id, property, nodeType, map)
+      }
+    }
+  }
+}

--- a/shared/src/main/scala/amf/validation/DialectValidations.scala
+++ b/shared/src/main/scala/amf/validation/DialectValidations.scala
@@ -98,6 +98,8 @@ object DialectValidations extends Validations {
     "GUID scalar type declared without unique constraint"
   )
 
+  val DuplicateTerm = validation("duplicate-term", "Vocabulary defines duplicate terms")
+
   override val levels: Map[String, Map[ProfileName, String]] = Map(
     ClosedShapeSpecificationWarning.id -> all(WARNING)
   )
@@ -116,6 +118,7 @@ object DialectValidations extends Validations {
     InvalidUnionType,
     InvalidDialectPatch,
     DialectError,
-    GuidRangeWithoutUnique
+    GuidRangeWithoutUnique,
+    DuplicateTerm
   )
 }

--- a/shared/src/test/resources/vocabularies2/production/streams/activity.expanded.jsonld
+++ b/shared/src/test/resources/vocabularies2/production/streams/activity.expanded.jsonld
@@ -396,7 +396,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(174,2)-(177,0)]"
+                        "@value": "[(171,2)-(174,0)]"
                       }
                     ]
                   }
@@ -437,46 +437,6 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(156,2)-(159,0)]"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "@id": "http://crm.com/vocabularies/core#Occupation",
-            "@type": [
-              "http://www.w3.org/2002/07/owl#Class",
-              "http://a.ml/vocabularies/document#DomainElement"
-            ],
-            "http://a.ml/vocabularies/core#name": [
-              {
-                "@value": "Occupation"
-              }
-            ],
-            "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-              {
-                "@id": "http://crm.com/vocabularies/core#CanonicalEntity"
-              }
-            ],
-            "http://a.ml/vocabularies/document-source-maps#sources": [
-              {
-                "@id": "http://crm.com/vocabularies/core#Occupation/source-map",
-                "@type": [
-                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
-                ],
-                "http://a.ml/vocabularies/document-source-maps#lexical": [
-                  {
-                    "@id": "http://crm.com/vocabularies/core#Occupation/source-map/lexical/element_0",
-                    "http://a.ml/vocabularies/document-source-maps#element": [
-                      {
-                        "@value": "http://crm.com/vocabularies/core#Occupation"
-                      }
-                    ],
-                    "http://a.ml/vocabularies/document-source-maps#value": [
-                      {
-                        "@value": "[(168,2)-(171,0)]"
                       }
                     ]
                   }
@@ -1024,7 +984,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(171,2)-(174,0)]"
+                        "@value": "[(168,2)-(171,0)]"
                       }
                     ]
                   }
@@ -1647,7 +1607,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(434,4)-(439,0)]"
+                        "@value": "[(431,4)-(436,0)]"
                       }
                     ]
                   }
@@ -1693,7 +1653,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(244,4)-(249,0)]"
+                        "@value": "[(241,4)-(246,0)]"
                       }
                     ]
                   }
@@ -1739,7 +1699,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(389,4)-(394,0)]"
+                        "@value": "[(386,4)-(391,0)]"
                       }
                     ]
                   }
@@ -1785,7 +1745,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(179,4)-(184,0)]"
+                        "@value": "[(176,4)-(181,0)]"
                       }
                     ]
                   }
@@ -1831,7 +1791,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(229,4)-(234,0)]"
+                        "@value": "[(226,4)-(231,0)]"
                       }
                     ]
                   }
@@ -1877,7 +1837,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(369,4)-(374,0)]"
+                        "@value": "[(366,4)-(371,0)]"
                       }
                     ]
                   }
@@ -1923,7 +1883,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(514,4)-(519,0)]"
+                        "@value": "[(511,4)-(516,0)]"
                       }
                     ]
                   }
@@ -1969,7 +1929,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(394,4)-(399,0)]"
+                        "@value": "[(391,4)-(396,0)]"
                       }
                     ]
                   }
@@ -2015,7 +1975,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(564,4)-(568,0)]"
+                        "@value": "[(561,4)-(565,0)]"
                       }
                     ]
                   }
@@ -2061,7 +2021,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(439,4)-(444,0)]"
+                        "@value": "[(436,4)-(441,0)]"
                       }
                     ]
                   }
@@ -2107,7 +2067,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(504,4)-(509,0)]"
+                        "@value": "[(501,4)-(506,0)]"
                       }
                     ]
                   }
@@ -2153,7 +2113,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(384,4)-(389,0)]"
+                        "@value": "[(381,4)-(386,0)]"
                       }
                     ]
                   }
@@ -2199,7 +2159,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(309,4)-(314,0)]"
+                        "@value": "[(306,4)-(311,0)]"
                       }
                     ]
                   }
@@ -2245,7 +2205,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(194,4)-(199,0)]"
+                        "@value": "[(191,4)-(196,0)]"
                       }
                     ]
                   }
@@ -2291,7 +2251,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(519,4)-(524,0)]"
+                        "@value": "[(516,4)-(521,0)]"
                       }
                     ]
                   }
@@ -2337,7 +2297,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(414,4)-(419,0)]"
+                        "@value": "[(411,4)-(416,0)]"
                       }
                     ]
                   }
@@ -2383,7 +2343,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(539,4)-(544,0)]"
+                        "@value": "[(536,4)-(541,0)]"
                       }
                     ]
                   }
@@ -2429,7 +2389,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(484,4)-(489,0)]"
+                        "@value": "[(481,4)-(486,0)]"
                       }
                     ]
                   }
@@ -2475,7 +2435,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(554,4)-(559,0)]"
+                        "@value": "[(551,4)-(556,0)]"
                       }
                     ]
                   }
@@ -2521,7 +2481,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(224,4)-(229,0)]"
+                        "@value": "[(221,4)-(226,0)]"
                       }
                     ]
                   }
@@ -2567,7 +2527,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(489,4)-(494,0)]"
+                        "@value": "[(486,4)-(491,0)]"
                       }
                     ]
                   }
@@ -2613,7 +2573,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(279,4)-(284,0)]"
+                        "@value": "[(276,4)-(281,0)]"
                       }
                     ]
                   }
@@ -2659,7 +2619,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(274,4)-(279,0)]"
+                        "@value": "[(271,4)-(276,0)]"
                       }
                     ]
                   }
@@ -2705,7 +2665,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(499,4)-(504,0)]"
+                        "@value": "[(496,4)-(501,0)]"
                       }
                     ]
                   }
@@ -2751,7 +2711,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(294,4)-(299,0)]"
+                        "@value": "[(291,4)-(296,0)]"
                       }
                     ]
                   }
@@ -2797,7 +2757,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(559,4)-(564,0)]"
+                        "@value": "[(556,4)-(561,0)]"
                       }
                     ]
                   }
@@ -2843,7 +2803,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(199,4)-(204,0)]"
+                        "@value": "[(196,4)-(201,0)]"
                       }
                     ]
                   }
@@ -2889,7 +2849,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(214,4)-(219,0)]"
+                        "@value": "[(211,4)-(216,0)]"
                       }
                     ]
                   }
@@ -2935,7 +2895,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(359,4)-(364,0)]"
+                        "@value": "[(356,4)-(361,0)]"
                       }
                     ]
                   }
@@ -2981,7 +2941,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(409,4)-(414,0)]"
+                        "@value": "[(406,4)-(411,0)]"
                       }
                     ]
                   }
@@ -3027,7 +2987,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(324,4)-(329,0)]"
+                        "@value": "[(321,4)-(326,0)]"
                       }
                     ]
                   }
@@ -3073,7 +3033,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(219,4)-(224,0)]"
+                        "@value": "[(216,4)-(221,0)]"
                       }
                     ]
                   }
@@ -3119,7 +3079,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(249,4)-(254,0)]"
+                        "@value": "[(246,4)-(251,0)]"
                       }
                     ]
                   }
@@ -3165,7 +3125,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(509,4)-(514,0)]"
+                        "@value": "[(506,4)-(511,0)]"
                       }
                     ]
                   }
@@ -3211,7 +3171,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(329,4)-(334,0)]"
+                        "@value": "[(326,4)-(331,0)]"
                       }
                     ]
                   }
@@ -3257,7 +3217,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(254,4)-(259,0)]"
+                        "@value": "[(251,4)-(256,0)]"
                       }
                     ]
                   }
@@ -3303,7 +3263,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(379,4)-(384,0)]"
+                        "@value": "[(376,4)-(381,0)]"
                       }
                     ]
                   }
@@ -3349,7 +3309,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(184,4)-(189,0)]"
+                        "@value": "[(181,4)-(186,0)]"
                       }
                     ]
                   }
@@ -3395,7 +3355,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(444,4)-(449,0)]"
+                        "@value": "[(441,4)-(446,0)]"
                       }
                     ]
                   }
@@ -3441,7 +3401,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(459,4)-(464,0)]"
+                        "@value": "[(456,4)-(461,0)]"
                       }
                     ]
                   }
@@ -3487,7 +3447,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(299,4)-(304,0)]"
+                        "@value": "[(296,4)-(301,0)]"
                       }
                     ]
                   }
@@ -3533,7 +3493,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(404,4)-(409,0)]"
+                        "@value": "[(401,4)-(406,0)]"
                       }
                     ]
                   }
@@ -3579,7 +3539,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(284,4)-(289,0)]"
+                        "@value": "[(281,4)-(286,0)]"
                       }
                     ]
                   }
@@ -3625,7 +3585,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(534,4)-(539,0)]"
+                        "@value": "[(531,4)-(536,0)]"
                       }
                     ]
                   }
@@ -3671,7 +3631,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(419,4)-(424,0)]"
+                        "@value": "[(416,4)-(421,0)]"
                       }
                     ]
                   }
@@ -3717,7 +3677,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(314,4)-(319,0)]"
+                        "@value": "[(311,4)-(316,0)]"
                       }
                     ]
                   }
@@ -3763,7 +3723,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(449,4)-(454,0)]"
+                        "@value": "[(446,4)-(451,0)]"
                       }
                     ]
                   }
@@ -3809,7 +3769,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(549,4)-(554,0)]"
+                        "@value": "[(546,4)-(551,0)]"
                       }
                     ]
                   }
@@ -3855,7 +3815,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(374,4)-(379,0)]"
+                        "@value": "[(371,4)-(376,0)]"
                       }
                     ]
                   }
@@ -3901,7 +3861,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(239,4)-(244,0)]"
+                        "@value": "[(236,4)-(241,0)]"
                       }
                     ]
                   }
@@ -3947,7 +3907,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(289,4)-(294,0)]"
+                        "@value": "[(286,4)-(291,0)]"
                       }
                     ]
                   }
@@ -3993,7 +3953,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(474,4)-(479,0)]"
+                        "@value": "[(471,4)-(476,0)]"
                       }
                     ]
                   }
@@ -4039,7 +3999,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(469,4)-(474,0)]"
+                        "@value": "[(466,4)-(471,0)]"
                       }
                     ]
                   }
@@ -4085,7 +4045,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(429,4)-(434,0)]"
+                        "@value": "[(426,4)-(431,0)]"
                       }
                     ]
                   }
@@ -4131,7 +4091,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(269,4)-(274,0)]"
+                        "@value": "[(266,4)-(271,0)]"
                       }
                     ]
                   }
@@ -4177,7 +4137,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(529,4)-(534,0)]"
+                        "@value": "[(526,4)-(531,0)]"
                       }
                     ]
                   }
@@ -4223,7 +4183,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(334,4)-(339,0)]"
+                        "@value": "[(331,4)-(336,0)]"
                       }
                     ]
                   }
@@ -4269,7 +4229,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(264,4)-(269,0)]"
+                        "@value": "[(261,4)-(266,0)]"
                       }
                     ]
                   }
@@ -4315,7 +4275,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(234,4)-(239,0)]"
+                        "@value": "[(231,4)-(236,0)]"
                       }
                     ]
                   }
@@ -4361,7 +4321,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(259,4)-(264,0)]"
+                        "@value": "[(256,4)-(261,0)]"
                       }
                     ]
                   }
@@ -4407,7 +4367,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(204,4)-(209,0)]"
+                        "@value": "[(201,4)-(206,0)]"
                       }
                     ]
                   }
@@ -4453,7 +4413,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(364,4)-(369,0)]"
+                        "@value": "[(361,4)-(366,0)]"
                       }
                     ]
                   }
@@ -4499,7 +4459,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(344,4)-(349,0)]"
+                        "@value": "[(341,4)-(346,0)]"
                       }
                     ]
                   }
@@ -4545,7 +4505,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(189,4)-(194,0)]"
+                        "@value": "[(186,4)-(191,0)]"
                       }
                     ]
                   }
@@ -4591,7 +4551,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(349,4)-(354,0)]"
+                        "@value": "[(346,4)-(351,0)]"
                       }
                     ]
                   }
@@ -4637,7 +4597,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(304,4)-(309,0)]"
+                        "@value": "[(301,4)-(306,0)]"
                       }
                     ]
                   }
@@ -4683,7 +4643,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(399,4)-(404,0)]"
+                        "@value": "[(396,4)-(401,0)]"
                       }
                     ]
                   }
@@ -4729,7 +4689,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(339,4)-(344,0)]"
+                        "@value": "[(336,4)-(341,0)]"
                       }
                     ]
                   }
@@ -4775,7 +4735,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(209,4)-(214,0)]"
+                        "@value": "[(206,4)-(211,0)]"
                       }
                     ]
                   }
@@ -4821,7 +4781,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(319,4)-(324,0)]"
+                        "@value": "[(316,4)-(321,0)]"
                       }
                     ]
                   }
@@ -4867,7 +4827,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(464,4)-(469,0)]"
+                        "@value": "[(461,4)-(466,0)]"
                       }
                     ]
                   }
@@ -4913,7 +4873,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(454,4)-(459,0)]"
+                        "@value": "[(451,4)-(456,0)]"
                       }
                     ]
                   }
@@ -4959,7 +4919,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(494,4)-(499,0)]"
+                        "@value": "[(491,4)-(496,0)]"
                       }
                     ]
                   }
@@ -5005,7 +4965,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(524,4)-(529,0)]"
+                        "@value": "[(521,4)-(526,0)]"
                       }
                     ]
                   }
@@ -5051,7 +5011,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(544,4)-(549,0)]"
+                        "@value": "[(541,4)-(546,0)]"
                       }
                     ]
                   }
@@ -5097,7 +5057,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(424,4)-(429,0)]"
+                        "@value": "[(421,4)-(426,0)]"
                       }
                     ]
                   }
@@ -5143,7 +5103,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(479,4)-(484,0)]"
+                        "@value": "[(476,4)-(481,0)]"
                       }
                     ]
                   }
@@ -5189,7 +5149,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(354,4)-(359,0)]"
+                        "@value": "[(351,4)-(356,0)]"
                       }
                     ]
                   }
@@ -5260,7 +5220,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
-                    "@value": "[(3,0)-(568,0)]"
+                    "@value": "[(3,0)-(565,0)]"
                   }
                 ]
               }

--- a/shared/src/test/resources/vocabularies2/production/streams/activity.flattened.jsonld
+++ b/shared/src/test/resources/vocabularies2/production/streams/activity.flattened.jsonld
@@ -175,9 +175,6 @@
           "@id": "http://crm.com/vocabularies/core#Ethnicity"
         },
         {
-          "@id": "http://crm.com/vocabularies/core#Occupation"
-        },
-        {
           "@id": "http://crm.com/vocabularies/core#Individual"
         },
         {
@@ -1041,24 +1038,6 @@
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "http://crm.com/vocabularies/core#Ethnicity/source-map"
-        }
-      ]
-    },
-    {
-      "@id": "http://crm.com/vocabularies/core#Occupation",
-      "@type": [
-        "http://www.w3.org/2002/07/owl#Class",
-        "http://a.ml/vocabularies/document#DomainElement"
-      ],
-      "http://a.ml/vocabularies/core#name": "Occupation",
-      "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-        {
-          "@id": "http://crm.com/vocabularies/core#CanonicalEntity"
-        }
-      ],
-      "http://a.ml/vocabularies/document-source-maps#sources": [
-        {
-          "@id": "http://crm.com/vocabularies/core#Occupation/source-map"
         }
       ]
     },
@@ -2052,6 +2031,26 @@
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "http://crm.com/vocabularies/core#LastKnownLocation/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "http://crm.com/vocabularies/core#Occupation",
+      "@type": [
+        "http://www.w3.org/2002/07/owl#DatatypeProperty",
+        "http://a.ml/vocabularies/meta#Property",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#displayName": "Occupation",
+      "http://a.ml/vocabularies/core#description": "Self declared information what occupation the person has",
+      "http://www.w3.org/2000/01/rdf-schema#range": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "http://crm.com/vocabularies/core#Occupation/source-map"
         }
       ]
     },
@@ -5545,17 +5544,6 @@
       ]
     },
     {
-      "@id": "http://crm.com/vocabularies/core#Occupation/source-map",
-      "@type": [
-        "http://a.ml/vocabularies/document-source-maps#SourceMap"
-      ],
-      "http://a.ml/vocabularies/document-source-maps#lexical": [
-        {
-          "@id": "http://crm.com/vocabularies/core#Occupation/source-map/lexical/element_0"
-        }
-      ]
-    },
-    {
       "@id": "http://crm.com/vocabularies/core#Individual/source-map",
       "@type": [
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
@@ -5992,6 +5980,17 @@
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
           "@id": "http://crm.com/vocabularies/core#LastKnownLocation/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "http://crm.com/vocabularies/core#Occupation/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "http://crm.com/vocabularies/core#Occupation/source-map/lexical/element_0"
         }
       ]
     },
@@ -6657,7 +6656,7 @@
     {
       "@id": "file://shared/src/test/resources/vocabularies2/production/streams/crm.yaml#/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "file://shared/src/test/resources/vocabularies2/production/streams/crm.yaml",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(568,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(565,0)]"
     },
     {
       "@id": "file://shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CanonicalIndividualChangeSetNode/property/PersonHeightUnitofMeasure/source-map",
@@ -8183,17 +8182,12 @@
     {
       "@id": "http://crm.com/vocabularies/core#Hobby/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#Hobby",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(174,2)-(177,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(171,2)-(174,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#Ethnicity/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#Ethnicity",
       "http://a.ml/vocabularies/document-source-maps#value": "[(156,2)-(159,0)]"
-    },
-    {
-      "@id": "http://crm.com/vocabularies/core#Occupation/source-map/lexical/element_0",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#Occupation",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(168,2)-(171,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#Individual/source-map/lexical/element_0",
@@ -8233,7 +8227,7 @@
     {
       "@id": "http://crm.com/vocabularies/core#MilitaryStatus/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MilitaryStatus",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(171,2)-(174,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(168,2)-(171,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#Language/source-map/lexical/element_0",
@@ -8308,387 +8302,392 @@
     {
       "@id": "http://crm.com/vocabularies/core#MainDietaryHabitType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MainDietaryHabitType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(434,4)-(439,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(431,4)-(436,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#NameSuffix/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#NameSuffix",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(244,4)-(249,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(241,4)-(246,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#YearlyIncome/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#YearlyIncome",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(389,4)-(394,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(386,4)-(391,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#Id/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#Id",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(179,4)-(184,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(176,4)-(181,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MiddleName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MiddleName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(229,4)-(234,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(226,4)-(231,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DeletionCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DeletionCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(369,4)-(374,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(366,4)-(371,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#GenderCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#GenderCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(514,4)-(519,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(511,4)-(516,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#YearlyIncomeCurrencyCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#YearlyIncomeCurrencyCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(394,4)-(399,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(391,4)-(396,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#WebSiteURL/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#WebSiteURL",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(564,4)-(568,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(561,4)-(565,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MainDisabilityType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MainDisabilityType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(439,4)-(444,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(436,4)-(441,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PrimaryHouseholdId/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PrimaryHouseholdId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(504,4)-(509,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(501,4)-(506,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#NetWorth/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#NetWorth",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(384,4)-(389,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(381,4)-(386,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#HasOptedOutProfiling/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#HasOptedOutProfiling",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(309,4)-(314,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(306,4)-(311,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#NoMergeReasonCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#NoMergeReasonCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(194,4)-(199,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(191,4)-(196,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ReligionCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ReligionCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(519,4)-(524,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(516,4)-(521,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MainPersonalityType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MainPersonalityType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(414,4)-(419,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(411,4)-(416,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#OccupationTypeCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#OccupationTypeCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(539,4)-(544,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(536,4)-(541,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#LastKnownLocation/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#LastKnownLocation",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(484,4)-(489,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(481,4)-(486,0)]"
+    },
+    {
+      "@id": "http://crm.com/vocabularies/core#Occupation/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#Occupation",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(551,4)-(556,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#FirstName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#FirstName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(224,4)-(229,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(221,4)-(226,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MaritalStatusCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MaritalStatusCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(489,4)-(494,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(486,4)-(491,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#HasOptedOutTracking/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#HasOptedOutTracking",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(279,4)-(284,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(276,4)-(281,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ResidenceCaptureMethodCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ResidenceCaptureMethodCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(274,4)-(279,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(271,4)-(276,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#EthnicityCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#EthnicityCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(499,4)-(504,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(496,4)-(501,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoNotTrackLocationUpdateDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoNotTrackLocationUpdateDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(294,4)-(299,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(291,4)-(296,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PrimaryHobbyCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PrimaryHobbyCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(559,4)-(564,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(556,4)-(561,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#SourceSystemId/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#SourceSystemId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(199,4)-(204,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(196,4)-(201,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PersonName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PersonName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(214,4)-(219,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(211,4)-(216,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#BirthDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#BirthDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(359,4)-(364,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(356,4)-(361,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ConsumerCreditScoreProviderName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ConsumerCreditScoreProviderName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(409,4)-(414,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(406,4)-(411,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoNotProcessFromUpdateDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoNotProcessFromUpdateDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(324,4)-(329,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(321,4)-(326,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#Salutation/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#Salutation",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(219,4)-(224,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(216,4)-(221,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#OfficialName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#OfficialName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(249,4)-(254,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(246,4)-(251,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DeathDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DeathDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(509,4)-(514,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(506,4)-(511,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoNotProcessReasonCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoNotProcessReasonCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(329,4)-(334,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(326,4)-(331,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MailingName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MailingName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(254,4)-(259,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(251,4)-(256,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PrimaryLanguageCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PrimaryLanguageCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(379,4)-(384,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(376,4)-(381,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PartyType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PartyType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(184,4)-(189,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(181,4)-(186,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PersonHeight/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PersonHeight",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(444,4)-(449,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(441,4)-(446,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PersonWeightUnitofMeasure/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PersonWeightUnitofMeasure",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(459,4)-(464,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(456,4)-(461,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#HasOptedOutSolicit/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#HasOptedOutSolicit",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(299,4)-(304,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(296,4)-(301,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ConsumerCreditScore/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ConsumerCreditScore",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(404,4)-(409,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(401,4)-(406,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoNotTrackUpdateDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoNotTrackUpdateDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(284,4)-(289,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(281,4)-(286,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ChildrenCount/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ChildrenCount",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(534,4)-(539,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(531,4)-(536,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MainPersonalValueType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MainPersonalValueType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(419,4)-(424,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(416,4)-(421,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoNotProfileFromUpdateDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoNotProfileFromUpdateDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(314,4)-(319,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(311,4)-(316,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PersonHeightUnitofMeasure/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PersonHeightUnitofMeasure",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(449,4)-(454,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(446,4)-(451,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MilitaryStatusCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MilitaryStatusCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(549,4)-(554,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(546,4)-(551,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#InfluencerRating/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#InfluencerRating",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(374,4)-(379,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(371,4)-(376,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#SecondFamilyName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#SecondFamilyName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(239,4)-(244,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(236,4)-(241,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#HasOptedOutGeoTracking/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#HasOptedOutGeoTracking",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(289,4)-(294,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(286,4)-(291,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#BirthPlace/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#BirthPlace",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(474,4)-(479,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(471,4)-(476,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#CountryofOrigin/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#CountryofOrigin",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(469,4)-(474,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(466,4)-(471,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MainLifeAttitudeType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MainLifeAttitudeType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(429,4)-(434,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(426,4)-(431,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ResidenceCountryCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ResidenceCountryCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(269,4)-(274,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(266,4)-(271,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#IsHomeOwner/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#IsHomeOwner",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(529,4)-(534,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(526,4)-(531,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ShouldForget/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ShouldForget",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(334,4)-(339,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(331,4)-(336,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#NickName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#NickName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(264,4)-(269,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(261,4)-(266,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#FamilyName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#FamilyName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(234,4)-(239,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(231,4)-(236,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#OrderingName/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#OrderingName",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(259,4)-(264,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(256,4)-(261,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#SourceRecordId/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#SourceRecordId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(204,4)-(209,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(201,4)-(206,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#OverAgeNumber/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#OverAgeNumber",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(364,4)-(369,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(361,4)-(366,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#SendIndividualData/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#SendIndividualData",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(344,4)-(349,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(341,4)-(346,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#GlobalPartyId/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#GlobalPartyId",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(189,4)-(194,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(186,4)-(191,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoExtractMyDataUpdateDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoExtractMyDataUpdateDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(349,4)-(354,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(346,4)-(351,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoNotMarketFromUpdateDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoNotMarketFromUpdateDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(304,4)-(309,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(301,4)-(306,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#YearlyIncomeRangeCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#YearlyIncomeRangeCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(399,4)-(404,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(396,4)-(401,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DoForgetMeFromUpdateDate/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DoForgetMeFromUpdateDate",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(339,4)-(344,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(336,4)-(341,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PhotoURL/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PhotoURL",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(209,4)-(214,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(206,4)-(211,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#HasOptedOutProcessing/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#HasOptedOutProcessing",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(319,4)-(324,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(316,4)-(321,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PrimaryCitizenshipCountryCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PrimaryCitizenshipCountryCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(464,4)-(469,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(461,4)-(466,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PersonWeight/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PersonWeight",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(454,4)-(459,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(451,4)-(456,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#PersonLifeStageCode/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#PersonLifeStageCode",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(494,4)-(499,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(491,4)-(496,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#ConvictionsCount/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#ConvictionsCount",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(524,4)-(529,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(521,4)-(526,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MilitaryServiceFlag/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MilitaryServiceFlag",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(544,4)-(549,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(541,4)-(546,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#MainLifeStyleType/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#MainLifeStyleType",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(424,4)-(429,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(421,4)-(426,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#DeathPlace/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#DeathPlace",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(479,4)-(484,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(476,4)-(481,0)]"
     },
     {
       "@id": "http://crm.com/vocabularies/core#CanStorePIIElsewhere/source-map/lexical/element_0",
       "http://a.ml/vocabularies/document-source-maps#element": "http://crm.com/vocabularies/core#CanStorePIIElsewhere",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(354,4)-(359,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(351,4)-(356,0)]"
     },
     {
       "@id": "file://shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CanonicalIndividualChangeSetNode/property/PersonHeightUnitofMeasure/source-map/lexical/element_1",

--- a/shared/src/test/resources/vocabularies2/production/streams/crm.yaml
+++ b/shared/src/test/resources/vocabularies2/production/streams/crm.yaml
@@ -165,9 +165,6 @@ classTerms:
   Religion:
     extends: CanonicalEntity
 
-  Occupation:
-    extends: CanonicalEntity
-
   MilitaryStatus:
     extends: CanonicalEntity
 


### PR DESCRIPTION
Ignore scalafmt differences. Core change is in method `checkDuplicatedTerms(map)`