### PR TITLE
Revert "Avoid data range validation for properties of range 'any'."

### DIFF
--- a/shared/src/main/scala/amf/plugins/document/vocabularies/validation/AMFDialectValidations.scala
+++ b/shared/src/main/scala/amf/plugins/document/vocabularies/validation/AMFDialectValidations.scala
@@ -1,7 +1,6 @@
 package amf.plugins.document.vocabularies.validation
 
 import amf.ProfileName
-import amf.client.model.DataTypes
 import amf.core.model.DataType
 import amf.core.rdf.RdfModel
 import amf.core.utils.AmfStrings
@@ -288,7 +287,7 @@ class AMFDialectValidations(val dialect: Dialect) extends DialectEmitterHelper {
                       datatype = Some((Namespace.Xsd + "string").iri())
                   ))
           )
-        case literal if literal != DataType.Any =>
+        case literal =>
           val message = s"Property '${prop.name()}'  value must be of type $dataRange"
           validations += new ValidationSpecification(
               name = validationId(node, prop.name().value(), "dataRange"),


### PR DESCRIPTION
This reverts commit 02929a1f42931d533cc25c7e40ba5fb09c16c168.

Duplicates fix: "Remove anyType property range validations"
In: bde422082da4e7386e3c642a613faddc42ce404a