### PR TITLE
Ambiguity checking

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/dialects/DialectContext.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/dialects/DialectContext.scala
@@ -10,7 +10,7 @@ class DialectContext(private val wrapped: ParserContext, private val ds: Option[
     with DialectSyntax
     with SyntaxErrorReporter {
 
-  def findInRecursiveShapes(key: String): Option[String] = {
+  def findInRecursiveUnits(key: String): Option[String] = {
     val qname = QName(key)
     if (qname.isQualified) {
       recursiveDeclarations.get(qname.qualification) match {

--- a/amf-aml/shared/src/main/scala/amf/validation/DialectValidations.scala
+++ b/amf-aml/shared/src/main/scala/amf/validation/DialectValidations.scala
@@ -43,6 +43,16 @@ object DialectValidations extends Validations {
     "Missing property range term"
   )
 
+  val UnavoidableAmbiguity = validation(
+      "unavoidable-ambiguity",
+      "Unavoidable ambiguity"
+  )
+
+  val EventualAmbiguity = validation(
+      "eventual-ambiguity",
+      "Eventual ambiguity"
+  )
+
   val DifferentTermsInMapKey = validation(
     "different-terms-in-mapkey",
     "Different terms in map key"

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-node/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-node/dialect.yaml
@@ -1,0 +1,25 @@
+#%Dialect 1.0
+dialect: Union Node
+#version: 1.0 comment version to force violation & non-conformity
+nodeMappings:
+  A:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+      propertyA:
+        range: integer
+        mandatory: false
+  B:
+    mapping:
+      propertyX:
+        range: string
+        mandatory: true
+      propertyB:
+        range: integer
+        mandatory: false
+
+  RootNode:
+    union:
+      - A
+      - B

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-node/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-node/report.json
@@ -1,0 +1,58 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-node/dialect.yaml"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Property: 'version' mandatory in a dialect node",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#mandatory-property-shape"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 2,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 25,
+          "http://a.ml/vocabularies/amf/parser#column": 9
+        }
+      }
+    },
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Warning"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-node/dialect.yaml#/declarations/RootNode"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union might be ambiguous. Members A, B have the same set of mandatory property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#eventual-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 22,
+          "http://a.ml/vocabularies/amf/parser#column": 2
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 25,
+          "http://a.ml/vocabularies/amf/parser#column": 9
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-property/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-property/dialect.yaml
@@ -1,0 +1,26 @@
+#%Dialect 1.0
+dialect: Union Node
+#version: 1.0 comment version to force violation & non-conformity
+nodeMappings:
+  A:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+      propertyA:
+        range: integer
+        mandatory: false
+  B:
+    mapping:
+      propertyX:
+        range: string
+        mandatory: true
+      propertyB:
+        range: integer
+        mandatory: false
+
+  RootNode:
+    mapping:
+      unionProp:
+        range: [A, B]
+        mandatory: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-property/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-property/report.json
@@ -1,0 +1,58 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-property/dialect.yaml"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Property: 'version' mandatory in a dialect node",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#mandatory-property-shape"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 2,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 26,
+          "http://a.ml/vocabularies/amf/parser#column": 23
+        }
+      }
+    },
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Warning"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/eventual-ambiguity-property/dialect.yaml#/declarations/RootNode/property/unionProp"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union might be ambiguous. Members A, B have the same set of mandatory property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#eventual-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 25,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 26,
+          "http://a.ml/vocabularies/amf/parser#column": 23
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-node/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-node/dialect.yaml
@@ -1,0 +1,46 @@
+#%Dialect 1.0
+dialect: Union Node
+#version: 1.0 comment version to force violation & non-conformity
+nodeMappings:
+  A: # is eventually ambiguous with C
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+      propertyA:
+        range: integer
+        mandatory: false
+  B:
+    mapping:
+      propertyY:
+        range: string
+        mandatory: true
+  C:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+      propertyC:
+        range: integer
+        mandatory: false
+
+  D:
+    mapping:
+      propertyZ:
+        range: string
+        mandatory: true
+
+  Union0:
+    union:
+      - A
+      - B
+
+  Union1:
+    union:
+      - C
+      - D
+
+  RootUnion:
+    union:
+      - Union0
+      - Union1

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-node/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-node/report.json
@@ -1,0 +1,58 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-node/dialect.yaml"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Property: 'version' mandatory in a dialect node",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#mandatory-property-shape"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 2,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 46,
+          "http://a.ml/vocabularies/amf/parser#column": 14
+        }
+      }
+    },
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Warning"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-node/dialect.yaml#/declarations/RootUnion"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union might be ambiguous. Members Union0/A, Union1/C have the same set of mandatory property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#eventual-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 43,
+          "http://a.ml/vocabularies/amf/parser#column": 2
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 46,
+          "http://a.ml/vocabularies/amf/parser#column": 14
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-property/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-property/dialect.yaml
@@ -1,0 +1,47 @@
+#%Dialect 1.0
+dialect: Union Node
+#version: 1.0 comment version to force violation & non-conformity
+nodeMappings:
+  A: # is eventually ambiguous with C
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+      propertyA:
+        range: integer
+        mandatory: false
+  B:
+    mapping:
+      propertyY:
+        range: string
+        mandatory: true
+  C:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+      propertyC:
+        range: integer
+        mandatory: false
+
+  D:
+    mapping:
+      propertyZ:
+        range: string
+        mandatory: true
+
+  Union0:
+    union:
+      - A
+      - B
+
+  Union1:
+    union:
+      - C
+      - D
+
+  RootUnion:
+    mapping:
+      unionProp:
+        range: [Union0, Union1]
+        mandatory: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-property/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-property/report.json
@@ -1,0 +1,58 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-property/dialect.yaml"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Property: 'version' mandatory in a dialect node",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#mandatory-property-shape"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 2,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 47,
+          "http://a.ml/vocabularies/amf/parser#column": 23
+        }
+      }
+    },
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Warning"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-eventual-ambiguity-property/dialect.yaml#/declarations/RootUnion/property/unionProp"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union might be ambiguous. Members Union0/A, Union1/C have the same set of mandatory property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#eventual-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 46,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 47,
+          "http://a.ml/vocabularies/amf/parser#column": 23
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-node/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-node/dialect.yaml
@@ -1,0 +1,39 @@
+#%Dialect 1.0
+dialect: Union Node
+version: 1.0
+nodeMappings:
+  A: # is ambiguous with C
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+  B:
+    mapping:
+      propertyY:
+        range: string
+        mandatory: true
+  C:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+  D:
+    mapping:
+      propertyZ:
+        range: string
+        mandatory: true
+
+  Union0:
+    union:
+      - A
+      - B
+
+  Union1:
+    union:
+      - C
+      - D
+
+  RootUnion:
+    union:
+      - Union0
+      - Union1

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-node/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-node/report.json
@@ -1,0 +1,32 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-node/dialect.yaml#/declarations/RootUnion"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union is ambiguous. Members Union0/A, Union1/C have the same set of property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#unavoidable-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 36,
+          "http://a.ml/vocabularies/amf/parser#column": 2
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 39,
+          "http://a.ml/vocabularies/amf/parser#column": 14
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-property/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-property/dialect.yaml
@@ -1,0 +1,40 @@
+#%Dialect 1.0
+dialect: Union Node
+version: 1.0
+nodeMappings:
+  A: # is ambiguous with C
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+  B:
+    mapping:
+      propertyY:
+        range: string
+        mandatory: true
+  C:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+  D:
+    mapping:
+      propertyZ:
+        range: string
+        mandatory: true
+
+  Union0:
+    union:
+      - A
+      - B
+
+  Union1:
+    union:
+      - C
+      - D
+
+  RootUnion:
+    mapping:
+      unionProp:
+        range: [Union0, Union1]
+        mandatory: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-property/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-property/report.json
@@ -1,0 +1,32 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/nested-unavoidable-ambiguity-property/dialect.yaml#/declarations/RootUnion/property/unionProp"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union is ambiguous. Members Union0/A, Union1/C have the same set of property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#unavoidable-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 39,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 40,
+          "http://a.ml/vocabularies/amf/parser#column": 23
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-node/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-node/dialect.yaml
@@ -1,0 +1,19 @@
+#%Dialect 1.0
+dialect: Union Node
+version: 1.0
+nodeMappings:
+  A:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+  B:
+    mapping:
+      propertyX:
+        range: string
+        mandatory: true
+
+  RootNode:
+    union:
+      - A
+      - B

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-node/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-node/report.json
@@ -1,0 +1,32 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-node/dialect.yaml#/declarations/RootNode"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union is ambiguous. Members A, B have the same set of property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#unavoidable-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 16,
+          "http://a.ml/vocabularies/amf/parser#column": 2
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 19,
+          "http://a.ml/vocabularies/amf/parser#column": 9
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-property/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-property/dialect.yaml
@@ -1,0 +1,20 @@
+#%Dialect 1.0
+dialect: Union Node
+version: 1.0
+nodeMappings:
+  A:
+    mapping:
+      propertyX:
+        range: integer
+        mandatory: true
+  B:
+    mapping:
+      propertyX:
+        range: string
+        mandatory: true
+
+  RootNode:
+    mapping:
+      unionProp:
+        range: [A, B]
+        mandatory: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-property/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-property/report.json
@@ -1,0 +1,32 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/unavoidable-ambiguity-property/dialect.yaml#/declarations/RootNode/property/unionProp"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Union is ambiguous. Members A, B have the same set of property names",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#unavoidable-ambiguity"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 19,
+          "http://a.ml/vocabularies/amf/parser#column": 0
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 20,
+          "http://a.ml/vocabularies/amf/parser#column": 23
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/scala/amf/dialects/DialectDefinitionValidationTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/DialectDefinitionValidationTest.scala
@@ -32,4 +32,38 @@ class DialectDefinitionValidationTest extends AsyncFunSuite with Matchers with D
   test("Test mandatory property mapping without value") {
     validate("/mandatory-property-mapping-without-value/dialect.yaml", Some("mandatory-property-mapping-without-value/report.json"))
   }
+
+  test("Test un-avoidable ambiguity in node") {
+    validate("/unavoidable-ambiguity-node/dialect.yaml", Some("unavoidable-ambiguity-node/report.json"))
+  }
+
+  test("Test un-avoidable ambiguity in property") {
+    validate("/unavoidable-ambiguity-property/dialect.yaml", Some("unavoidable-ambiguity-property/report.json"))
+  }
+
+  test("Test eventual ambiguity in node") {
+    validate("/eventual-ambiguity-node/dialect.yaml", Some("eventual-ambiguity-node/report.json"))
+  }
+
+  test("Test eventual ambiguity in property") {
+    validate("/eventual-ambiguity-property/dialect.yaml", Some("eventual-ambiguity-property/report.json"))
+  }
+
+  test("Test nested un-avoidable ambiguity in node") {
+    validate("/nested-unavoidable-ambiguity-node/dialect.yaml", Some("nested-unavoidable-ambiguity-node/report.json"))
+  }
+
+  test("Test nested un-avoidable ambiguity in property") {
+    validate("/nested-unavoidable-ambiguity-property/dialect.yaml", Some("nested-unavoidable-ambiguity-property/report.json"))
+  }
+
+  test("Test nested eventual ambiguity in node") {
+    validate("/nested-eventual-ambiguity-node/dialect.yaml", Some("nested-eventual-ambiguity-node/report.json"))
+  }
+
+  test("Test nested eventual ambiguity in property") {
+    validate("/nested-eventual-ambiguity-property/dialect.yaml", Some("nested-eventual-ambiguity-property/report.json"))
+  }
+
+
 }

--- a/amf-custom-validation/shared/src/main/scala/amf/plugins/features/validation/custom/model/ValidationDialectText.scala
+++ b/amf-custom-validation/shared/src/main/scala/amf/plugins/features/validation/custom/model/ValidationDialectText.scala
@@ -157,6 +157,7 @@ object ValidationDialectText {
       |        propertyTerm: shacl.and
       |        range: [ shapeValidationNode, queryValidationNode, functionValidationNode, xoneShapeValidationNode, orShapeValidationNode, notShapeValidationNode, andShapeValidationNode]
       |        allowMultiple: true
+      |        mandatory: true
       |  notShapeValidationNode:
       |    classTerm: validation.NotShapeValidation
       |    mapping:
@@ -173,6 +174,7 @@ object ValidationDialectText {
       |      not:
       |        propertyTerm: shacl.not
       |        range: [ shapeValidationNode, queryValidationNode, functionValidationNode, xoneShapeValidationNode, orShapeValidationNode, notShapeValidationNode, andShapeValidationNode]
+      |        mandatory: true
       |  orShapeValidationNode:
       |    classTerm: validation.OrShapeValidation
       |    mapping:
@@ -190,6 +192,7 @@ object ValidationDialectText {
       |        propertyTerm: shacl.or
       |        range: [ shapeValidationNode, queryValidationNode, functionValidationNode, xoneShapeValidationNode, orShapeValidationNode, notShapeValidationNode, andShapeValidationNode]
       |        allowMultiple: true
+      |        mandatory: true
       |  xoneShapeValidationNode:
       |    classTerm: validation.XoneShapeValidation
       |    mapping:
@@ -207,6 +210,7 @@ object ValidationDialectText {
       |        propertyTerm: shacl.xone
       |        range: [ shapeValidationNode, queryValidationNode, functionValidationNode, xoneShapeValidationNode, orShapeValidationNode, notShapeValidationNode, andShapeValidationNode]
       |        allowMultiple: true
+      |        mandatory: true
       |  queryValidationNode:
       |    classTerm: validation.QueryValidation
       |    mapping:


### PR DESCRIPTION
Added ambiguity checking for unions as described in the [aml spec's schema inference section](https://github.com/aml-org/aml-spec/blob/master/dialects.md#schema-inference)

@antoniogarrote Had to make a small modification to the validation dialect to avoid eventual ambiguity warnings. Can you take a look at it?