### PR TITLE
APIMF-2822: moved urlEncoding to final statement in dialect instance node id manufactering to encode idTemplate defined uris

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/InstanceNodeIdHandling.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/InstanceNodeIdHandling.scala
@@ -47,7 +47,7 @@ trait InstanceNodeIdHandling extends BaseDirectiveOverride { this: DialectInstan
         defaultId
       }
     }
-    overrideBase(generatedId, nodeMap)
+    overrideBase(generatedId, nodeMap).urlEncoded
   }
 
 
@@ -117,7 +117,7 @@ trait InstanceNodeIdHandling extends BaseDirectiveOverride { this: DialectInstan
     template
   }
 
-  protected def primaryKeyNodeId(node: DialectDomainElement,
+  private def primaryKeyNodeId(node: DialectDomainElement,
                                  nodeMap: YMap,
                                  path: Seq[String],
                                  defaultId: String,
@@ -139,7 +139,7 @@ trait InstanceNodeIdHandling extends BaseDirectiveOverride { this: DialectInstan
           }
       }
     }
-    if (allFound) { path.map(_.urlEncoded).mkString("/") + "/" + keyId.mkString("_").urlEncoded }
+    if (allFound) { path.mkString("/") + "/" + keyId.mkString("_") }
     else { defaultId }
   }
 

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/dialect.yaml
@@ -1,0 +1,16 @@
+#%Dialect 1.0
+dialect: Football_Players
+version: 1.0
+
+nodeMappings:
+  PlayerNode:
+    idTemplate: http://someUri/{playerName}
+    mapping:
+      playerName:
+        range: string
+        mandatory: true
+        unique: true
+
+documents:
+  root:
+    encodes: PlayerNode

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.expanded.jsonld
@@ -1,0 +1,101 @@
+[
+  {
+    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/meta#DialectInstance",
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/meta#definedBy": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/dialect.yaml"
+      }
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "http://someUri/Lionel%20Messi",
+        "@type": [
+          "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/dialect.yaml#/declarations/PlayerNode",
+          "http://a.ml/vocabularies/meta#DialectDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/data#playerName": [
+          {
+            "@value": "Lionel Messi"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "http://someUri/Lionel%20Messi#/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "http://someUri/Lionel%20Messi#/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://someUri/Lionel%20Messi"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(2,0)-(3,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "http://someUri/Lionel%20Messi#/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/data#playerName"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(2,0)-(3,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "2.3.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document-source-maps#sources": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml#/source-map",
+        "@type": [
+          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        ],
+        "http://a.ml/vocabularies/document-source-maps#lexical": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml#/source-map/lexical/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(3,0)]"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.flattened.jsonld
@@ -1,0 +1,101 @@
+[
+  {
+    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/meta#DialectInstance",
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/meta#definedBy": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/dialect.yaml"
+      }
+    ],
+    "http://a.ml/vocabularies/document#encodes": [
+      {
+        "@id": "http://someUri/Lionel%20Messi",
+        "@type": [
+          "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/dialect.yaml#/declarations/PlayerNode",
+          "http://a.ml/vocabularies/meta#DialectDomainElement",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/data#playerName": [
+          {
+            "@value": "Lionel Messi"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "http://someUri/Lionel%20Messi#/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "http://someUri/Lionel%20Messi#/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://someUri/Lionel%20Messi"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(2,0)-(3,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "http://someUri/Lionel%20Messi#/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/data#playerName"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(2,0)-(3,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "2.3.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document-source-maps#sources": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml#/source-map",
+        "@type": [
+          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        ],
+        "http://a.ml/vocabularies/document-source-maps#lexical": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml#/source-map/lexical/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(3,0)]"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/encoded-id-template/instance.yaml
@@ -1,0 +1,2 @@
+#%Football_Players 1.0
+playerName: Lionel Messi

--- a/amf-aml/shared/src/test/scala/amf/dialects/DialectInstancesParsingTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/DialectInstancesParsingTest.scala
@@ -925,6 +925,17 @@ trait DialectInstancesParsingTest extends DialectTests {
     )
   }
 
+  multiGoldenTest("Id produced from idTemplate is encoded", "instance.%s") { config =>
+    withDialect(
+      "dialect.yaml",
+      "instance.yaml",
+      config.golden,
+      VocabularyYamlHint,
+      target = Amf,
+      directory = s"$basePath/encoded-id-template/"
+    )
+  }
+
 
   protected def withInlineDialect(source: String,
                                   golden: String,


### PR DESCRIPTION
Same as https://github.com/aml-org/amf-aml/pull/175. Had to create new branch with new PR because Jenkins wasn't analyzing the old one.