### PR TITLE
ALS-1390: Changes required for ALS Vocabularies support

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesParser.scala
@@ -3,6 +3,7 @@ package amf.plugins.document.vocabularies.parser.vocabularies
 import amf.core.Root
 import amf.core.model.DataType
 import amf.core.model.document.BaseUnit
+import amf.core.model.domain.{AmfArray, AmfScalar}
 import amf.core.parser.{BaseSpecParser, _}
 import amf.core.vocabulary.Namespace
 import amf.plugins.document.vocabularies.metamodel.document.VocabularyModel
@@ -119,10 +120,10 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
               case YType.Null => Seq.empty
             }
 
-            val properties: Seq[String] = refs
+            val properties: Seq[AmfScalar] = refs
               .map { term: String =>
                 ctx.resolvePropertyTermAlias(vocabulary.base.value(), term, entry.value, strictLocal = true) match {
-                  case Some(v) => Some(v)
+                  case Some(v) => Some(AmfScalar(v))
                   case None =>
                     ctx.missingPropertyTermWarning(term, classTerm.id, entry.value)
                     None
@@ -132,7 +133,7 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
               .map(_.get)
 
             if (properties.nonEmpty)
-              classTerm.set(ClassTermModel.Properties, properties)
+              classTerm.set(ClassTermModel.Properties, AmfArray(properties, Annotations(entry.value)), Annotations(entry))
           }
         )
 

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/vocabularies/VocabulariesParser.scala
@@ -116,6 +116,7 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
               case YType.Seq =>
                 DefaultArrayNode(entry.value).nodes._1
                   .map(_.value.toString) // ArrayNode(entry.value).strings().scalars.map(_.toString)
+              case YType.Null => Seq.empty
             }
 
             val properties: Seq[String] = refs
@@ -143,6 +144,7 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
               case YType.Seq =>
                 // ArrayNode(entry.value).strings().scalars.map(_.toString)
                 DefaultArrayNode(node = entry.value).nodes._1.map(_.value.toString)
+              case YType.Null => Seq.empty
             }
 
             val superClasses: Seq[String] = refs
@@ -254,6 +256,7 @@ class VocabulariesParser(root: Root)(implicit override val ctx: VocabularyContex
               case YType.Seq =>
                 DefaultArrayNode(entry.value).nodes._1.map(_.as[YScalar].text)
               // ArrayNode(entry.value).strings().scalars.map(_.toString)
+              case YType.Null => Seq.empty
             }
 
             val superClasses: Seq[String] = refs

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/ABOUT/ABOUT-dialect.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/ABOUT/ABOUT-dialect.expanded.jsonld
@@ -674,7 +674,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_0",
+                    "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://mulesoft.com/vocabularies/about#License"
@@ -683,6 +683,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(60,2)-(68,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(64,4)-(68,0)]"
                       }
                     ]
                   }
@@ -730,7 +743,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_0",
+                    "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://mulesoft.com/vocabularies/about#DiscussionChannel"
@@ -739,6 +752,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(34,2)-(42,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(37,4)-(42,0)]"
                       }
                     ]
                   }
@@ -785,7 +811,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_0",
+                    "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://mulesoft.com/vocabularies/about#Contributor"
@@ -794,6 +820,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(68,2)-(75,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(72,4)-(75,0)]"
                       }
                     ]
                   }
@@ -930,7 +969,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_0",
+                    "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://mulesoft.com/vocabularies/about#SoftwareProject"
@@ -939,6 +978,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(18,2)-(34,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(21,4)-(34,0)]"
                       }
                     ]
                   }

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/ABOUT/ABOUT-dialect.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/ABOUT/ABOUT-dialect.flattened.jsonld
@@ -2579,6 +2579,9 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_1"
+        },
+        {
           "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_0"
         }
       ]
@@ -2590,6 +2593,9 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
+          "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_1"
+        },
+        {
           "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_0"
         }
       ]
@@ -2600,6 +2606,9 @@
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_1"
+        },
         {
           "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_0"
         }
@@ -2633,6 +2642,9 @@
         "http://a.ml/vocabularies/document-source-maps#SourceMap"
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_1"
+        },
         {
           "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_0"
         }
@@ -3732,19 +3744,34 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(50,2)-(55,0)]"
     },
     {
-      "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_0",
+      "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://mulesoft.com/vocabularies/about#License",
       "http://a.ml/vocabularies/document-source-maps#value": "[(60,2)-(68,0)]"
     },
     {
-      "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_0",
+      "@id": "http://mulesoft.com/vocabularies/about#License/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#properties",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(64,4)-(68,0)]"
+    },
+    {
+      "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://mulesoft.com/vocabularies/about#DiscussionChannel",
       "http://a.ml/vocabularies/document-source-maps#value": "[(34,2)-(42,0)]"
     },
     {
-      "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_0",
+      "@id": "http://mulesoft.com/vocabularies/about#DiscussionChannel/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#properties",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(37,4)-(42,0)]"
+    },
+    {
+      "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://mulesoft.com/vocabularies/about#Contributor",
       "http://a.ml/vocabularies/document-source-maps#value": "[(68,2)-(75,0)]"
+    },
+    {
+      "@id": "http://mulesoft.com/vocabularies/about#Contributor/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#properties",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(72,4)-(75,0)]"
     },
     {
       "@id": "http://mulesoft.com/vocabularies/about#ProjectManagement/source-map/lexical/element_0",
@@ -3757,9 +3784,14 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(42,2)-(50,0)]"
     },
     {
-      "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_0",
+      "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://mulesoft.com/vocabularies/about#SoftwareProject",
       "http://a.ml/vocabularies/document-source-maps#value": "[(18,2)-(34,0)]"
+    },
+    {
+      "@id": "http://mulesoft.com/vocabularies/about#SoftwareProject/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#properties",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(21,4)-(34,0)]"
     },
     {
       "@id": "http://mulesoft.com/vocabularies/about#serviceType/source-map/lexical/element_0",

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/Instagram/dialect.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/Instagram/dialect.json
@@ -296,7 +296,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://mulesoft.com/vocabularies/amf-learning#Person/source-map/lexical/element_0",
+                    "@id": "http://mulesoft.com/vocabularies/amf-learning#Person/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://mulesoft.com/vocabularies/amf-learning#Person"
@@ -305,6 +305,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(15,2)-(21,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://mulesoft.com/vocabularies/amf-learning#Person/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(18,4)-(21,0)]"
                       }
                     ]
                   }

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.json
@@ -686,7 +686,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://crm.com/vocabularies/core#Individual/source-map/lexical/element_0",
+                    "@id": "http://crm.com/vocabularies/core#Individual/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://crm.com/vocabularies/core#Individual"
@@ -695,6 +695,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(28,2)-(105,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://crm.com/vocabularies/core#Individual/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(30,4)-(105,0)]"
                       }
                     ]
                   }
@@ -856,7 +869,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://crm.com/vocabularies/core#CanonicalEntity/source-map/lexical/element_0",
+                    "@id": "http://crm.com/vocabularies/core#CanonicalEntity/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://crm.com/vocabularies/core#CanonicalEntity"
@@ -865,6 +878,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(10,2)-(16,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://crm.com/vocabularies/core#CanonicalEntity/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(13,4)-(16,0)]"
                       }
                     ]
                   }
@@ -1553,7 +1579,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "http://crm.com/vocabularies/core#Party/source-map/lexical/element_0",
+                    "@id": "http://crm.com/vocabularies/core#Party/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://crm.com/vocabularies/core#Party"
@@ -1562,6 +1588,19 @@
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
                         "@value": "[(16,2)-(25,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "http://crm.com/vocabularies/core#Party/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#properties"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(18,4)-(25,0)]"
                       }
                     ]
                   }

--- a/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.expanded.jsonld
@@ -1,0 +1,154 @@
+[
+  {
+    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/meta#Vocabulary",
+      "http://www.w3.org/2002/07/owl#Ontology",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/core#name": [
+      {
+        "@value": "test8"
+      }
+    ],
+    "http://a.ml/vocabularies/meta#base": [
+      {
+        "@value": "http://a.ml/vocabularies/test8#"
+      }
+    ],
+    "http://a.ml/vocabularies/document#location": [
+      {
+        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml"
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "3.0.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document-source-maps#sources": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map",
+        "@type": [
+          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        ],
+        "http://a.ml/vocabularies/document-source-maps#lexical": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_2",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/core#name"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(3,0)-(4,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/meta#base"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(3,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_1",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(10,12)]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "http://a.ml/vocabularies/test8#emptyExtend",
+        "@type": [
+          "http://www.w3.org/2002/07/owl#Class",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "emptyExtend"
+          }
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf": [],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "http://a.ml/vocabularies/test8#emptyExtend/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "http://a.ml/vocabularies/test8#emptyExtend/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/test8#emptyExtend"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(9,2)-(10,12)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "http://a.ml/vocabularies/test8#emptyExtends",
+        "@type": [
+          "http://www.w3.org/2002/07/owl#DatatypeProperty",
+          "http://a.ml/vocabularies/meta#Property",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "http://a.ml/vocabularies/test8#emptyExtends/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "http://a.ml/vocabularies/test8#emptyExtends/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/test8#emptyExtends"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(5,2)-(8,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.flattened.jsonld
@@ -1,0 +1,122 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "http://a.ml/vocabularies/test8#emptyExtend"
+        },
+        {
+          "@id": "http://a.ml/vocabularies/test8#emptyExtends"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/meta#Vocabulary",
+        "http://www.w3.org/2002/07/owl#Ontology",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/core#name": "test8",
+      "http://a.ml/vocabularies/meta#base": "http://a.ml/vocabularies/test8#",
+      "http://a.ml/vocabularies/document#location": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml",
+      "http://a.ml/vocabularies/document#version": "3.0.0",
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test8#emptyExtend",
+      "@type": [
+        "http://www.w3.org/2002/07/owl#Class",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "emptyExtend",
+      "http://www.w3.org/2000/01/rdf-schema#subClassOf": [],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "http://a.ml/vocabularies/test8#emptyExtend/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test8#emptyExtends",
+      "@type": [
+        "http://www.w3.org/2002/07/owl#DatatypeProperty",
+        "http://a.ml/vocabularies/meta#Property",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://www.w3.org/2000/01/rdf-schema#subPropertyOf": [],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "http://a.ml/vocabularies/test8#emptyExtends/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test8#emptyExtend/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "http://a.ml/vocabularies/test8#emptyExtend/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test8#emptyExtends/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "http://a.ml/vocabularies/test8#emptyExtends/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(4,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#base",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(3,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml#/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(10,12)]"
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test8#emptyExtend/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/test8#emptyExtend",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,2)-(10,12)]"
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test8#emptyExtends/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/test8#emptyExtends",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(8,0)]"
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example8.yaml
@@ -1,0 +1,10 @@
+#%Vocabulary 1.0
+base: http://a.ml/vocabularies/test8#
+vocabulary: test8
+propertyTerms:
+  emptyExtends:
+    extends:
+
+classTerms:
+  emptyExtend:
+    extends:

--- a/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.expanded.jsonld
@@ -1,0 +1,121 @@
+[
+  {
+    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/meta#Vocabulary",
+      "http://www.w3.org/2002/07/owl#Ontology",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/core#name": [
+      {
+        "@value": "test9"
+      }
+    ],
+    "http://a.ml/vocabularies/meta#base": [
+      {
+        "@value": "http://a.ml/vocabularies/test9#"
+      }
+    ],
+    "http://a.ml/vocabularies/document#location": [
+      {
+        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml"
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "3.0.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document-source-maps#sources": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map",
+        "@type": [
+          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        ],
+        "http://a.ml/vocabularies/document-source-maps#lexical": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_2",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/core#name"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(3,0)-(4,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/meta#base"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(3,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_1",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(6,17)]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "http://a.ml/vocabularies/test9#t",
+        "@type": [
+          "http://www.w3.org/2002/07/owl#Class",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "t"
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "http://a.ml/vocabularies/test9#t/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "http://a.ml/vocabularies/test9#t/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/test9#t"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(5,2)-(6,17)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.flattened.jsonld
@@ -1,0 +1,88 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "http://a.ml/vocabularies/test9#t"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/meta#Vocabulary",
+        "http://www.w3.org/2002/07/owl#Ontology",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/core#name": "test9",
+      "http://a.ml/vocabularies/meta#base": "http://a.ml/vocabularies/test9#",
+      "http://a.ml/vocabularies/document#location": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml",
+      "http://a.ml/vocabularies/document#version": "3.0.0",
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test9#t",
+      "@type": [
+        "http://www.w3.org/2002/07/owl#Class",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "t",
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "http://a.ml/vocabularies/test9#t/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test9#t/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "http://a.ml/vocabularies/test9#t/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(4,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#base",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(3,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml#/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(6,17)]"
+    },
+    {
+      "@id": "http://a.ml/vocabularies/test9#t/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/test9#t",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(5,2)-(6,17)]"
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/vocabularies/example9.yaml
@@ -1,0 +1,6 @@
+#%Vocabulary 1.0
+base: http://a.ml/vocabularies/test9#
+vocabulary: test9
+classTerms:
+  t:
+    properties: *

--- a/amf-aml/shared/src/test/scala/amf/dialects/VocabularyParsingTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/VocabularyParsingTest.scala
@@ -38,6 +38,14 @@ class VocabularyParsingTest extends DialectTests {
     cycle("example7.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
   }
 
+  multiGoldenTest("parse 8 test", "example8.%s") { config =>
+    cycle("example8.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+  }
+
+  multiGoldenTest("parse 9 test", "example9.%s") { config =>
+    cycle("example9.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+  }
+
   multiSourceTest("generate 1 test", "example1.%s") { config =>
     cycle(config.source, "example1.yaml", AmfJsonHint, target = Aml)
   }


### PR DESCRIPTION
- Fixes possible scala MatchError when keys "extends" or "properties" are present but their values are missing
- Adds missing annotations for class term properties