### PR TITLE
return BaseUnit in parsing plugin parse method

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/AMLPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/AMLPlugin.scala
@@ -35,7 +35,11 @@ import amf.plugins.document.vocabularies.parser.dialects.{DialectContext, Dialec
 import amf.plugins.document.vocabularies.parser.instances._
 import amf.plugins.document.vocabularies.parser.vocabularies.{VocabulariesParser, VocabularyContext}
 import amf.plugins.document.vocabularies.plugin.headers._
-import amf.plugins.document.vocabularies.resolution.pipelines.{DialectInstancePatchResolutionPipeline, DialectInstanceResolutionPipeline, DialectResolutionPipeline}
+import amf.plugins.document.vocabularies.resolution.pipelines.{
+  DialectInstancePatchResolutionPipeline,
+  DialectInstanceResolutionPipeline,
+  DialectResolutionPipeline
+}
 import org.yaml.model._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,7 +49,7 @@ object AMLPlugin extends AMLPlugin {
     AMFPluginsRegistry.documentPluginForID(this.ID).collect({ case a: AMLPlugin => a }).getOrElse(this)
 }
 
-object AMLParsePlugin extends AMFParsePluginAdapter(AMLPlugin)
+object AMLParsePlugin  extends AMFParsePluginAdapter(AMLPlugin)
 object AMLRenderPlugin extends AMFRenderPluginAdapter(AMLPlugin)
 
 trait AMLPlugin
@@ -66,34 +70,34 @@ trait AMLPlugin
   override def init()(implicit executionContext: ExecutionContext): Future[AMFPlugin] = Future { this }
 
   override def modelEntities: Seq[Obj] = Seq(
-    VocabularyModel,
-    ExternalModel,
-    VocabularyReferenceModel,
-    ClassTermModel,
-    ObjectPropertyTermModel,
-    DatatypePropertyTermModel,
-    DialectModel,
-    NodeMappingModel,
-    UnionNodeMappingModel,
-    PropertyMappingModel,
-    DocumentsModelModel,
-    PublicNodeMappingModel,
-    DocumentMappingModel,
-    DialectLibraryModel,
-    DialectFragmentModel,
-    DialectInstanceModel,
-    DialectInstanceLibraryModel,
-    DialectInstanceFragmentModel,
-    DialectInstancePatchModel
+      VocabularyModel,
+      ExternalModel,
+      VocabularyReferenceModel,
+      ClassTermModel,
+      ObjectPropertyTermModel,
+      DatatypePropertyTermModel,
+      DialectModel,
+      NodeMappingModel,
+      UnionNodeMappingModel,
+      PropertyMappingModel,
+      DocumentsModelModel,
+      PublicNodeMappingModel,
+      DocumentMappingModel,
+      DialectLibraryModel,
+      DialectFragmentModel,
+      DialectInstanceModel,
+      DialectInstanceLibraryModel,
+      DialectInstanceFragmentModel,
+      DialectInstancePatchModel
   )
 
   override def serializableAnnotations(): Map[String, AnnotationGraphLoader] =
     Map(
-      "aliases-location" -> AliasesLocation,
-      "custom-id"        -> CustomId,
-      "custom-base"      -> CustomBase,
-      "ref-include"      -> RefInclude,
-      "json-pointer-ref" -> JsonPointerRef
+        "aliases-location" -> AliasesLocation,
+        "custom-id"        -> CustomId,
+        "custom-base"      -> CustomBase,
+        "ref-include"      -> RefInclude,
+        "json-pointer-ref" -> JsonPointerRef
     )
 
   /**
@@ -117,32 +121,32 @@ trait AMLPlugin
     * this domain
     */
   override def documentSyntaxes: Seq[String] = Seq(
-    "application/aml+json",
-    "application/aml+yaml",
-    "application/raml",
-    "application/raml+json",
-    "application/raml+yaml",
-    "text/yaml",
-    "text/x-yaml",
-    "application/yaml",
-    "application/x-yaml",
-    "application/json"
+      "application/aml+json",
+      "application/aml+yaml",
+      "application/raml",
+      "application/raml+json",
+      "application/raml+yaml",
+      "text/yaml",
+      "text/x-yaml",
+      "application/yaml",
+      "application/x-yaml",
+      "application/json"
   )
 
   /**
     * Parses an accepted document returning an optional BaseUnit
     */
-  override def parse(document: Root, parentContext: ParserContext, options: ParsingOptions): Option[BaseUnit] = {
+  override def parse(document: Root, parentContext: ParserContext, options: ParsingOptions): BaseUnit = {
 
     val header = DialectHeader.dialectHeaderDirective(document)
 
     header match {
       case Some(ExtensionHeader.VocabularyHeader) =>
-        Some(new VocabulariesParser(document)(new VocabularyContext(parentContext)).parseDocument())
+        new VocabulariesParser(document)(new VocabularyContext(parentContext)).parseDocument()
       case Some(ExtensionHeader.DialectLibraryHeader) =>
-        Some(new DialectsParser(document)(cleanDialectContext(parentContext, document)).parseLibrary())
+        new DialectsParser(document)(cleanDialectContext(parentContext, document)).parseLibrary()
       case Some(ExtensionHeader.DialectFragmentHeader) =>
-        Some(new DialectsParser(document)(new DialectContext(parentContext)).parseFragment())
+        new DialectsParser(document)(new DialectContext(parentContext)).parseFragment()
       case Some(ExtensionHeader.DialectHeader) =>
         parseAndRegisterDialect(document, cleanDialectContext(parentContext, document))
       case _ => parseDialectInstance(document, header, parentContext)
@@ -210,18 +214,17 @@ trait AMLPlugin
       .parseDocument() match {
       case dialect: Dialect if dialect.hasValidHeader =>
         registry.register(dialect)
-        Some(dialect)
-      case unit => Some(unit)
+        dialect
+      case unit => unit
     }
   }
-
 
   override protected[amf] def getRemodValidatePlugins(): Seq[AMFValidatePlugin] = Seq(amlPlugin())
 
   protected def parseDocumentWithDialect(document: Root,
                                          parentContext: ParserContext,
                                          dialect: Dialect,
-                                         header: Option[String]): Option[DialectInstanceUnit] = {
+                                         header: Option[String]): DialectInstanceUnit = {
     registry.withRegisteredDialect(dialect) { resolvedDialect =>
       header match {
         case Some(headerKey) if resolvedDialect.isFragmentHeader(headerKey) =>
@@ -229,10 +232,11 @@ trait AMLPlugin
           new DialectInstanceFragmentParser(document)(new DialectInstanceContext(resolvedDialect, parentContext))
             .parse(name)
         case Some(headerKey) if resolvedDialect.isLibraryHeader(headerKey) =>
-          new DialectInstanceLibraryParser(document)(new DialectInstanceContext(resolvedDialect, parentContext)).parse()
+          new DialectInstanceLibraryParser(document)(new DialectInstanceContext(resolvedDialect, parentContext))
+            .parse()
         case Some(headerKey) if resolvedDialect.isPatchHeader(headerKey) =>
           new DialectInstancePatchParser(document)(
-            new DialectInstanceContext(resolvedDialect, parentContext).forPatch())
+              new DialectInstanceContext(resolvedDialect, parentContext).forPatch())
             .parse()
         case _ =>
           new DialectInstanceParser(document)(new DialectInstanceContext(resolvedDialect, parentContext))

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
@@ -62,16 +62,7 @@ class DialectsRegistry extends AMFDomainEntityResolver with PlatformSecrets {
 
   def dialectById(id: String): Option[Dialect] = map.values.find(_.id == id)
 
-  def withRegisteredDialect(header: String)(k: Dialect => Option[DialectInstanceUnit]): Option[DialectInstanceUnit] = {
-    val dialectId = headerKey(header.split("\\|").head)
-    map.get(dialectId) match {
-      case Some(dialect) => withRegisteredDialect(dialect)(k)
-      case _             => None
-    }
-  }
-
-  def withRegisteredDialect(dialect: Dialect)(
-      fn: Dialect => Option[DialectInstanceUnit]): Option[DialectInstanceUnit] = {
+  def withRegisteredDialect(dialect: Dialect)(fn: Dialect => DialectInstanceUnit): DialectInstanceUnit = {
     if (!resolved.contains(dialect.header))
       fn(resolveDialect(dialect))
     else

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/DialectInstanceLibraryParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/DialectInstanceLibraryParser.scala
@@ -4,9 +4,10 @@ import amf.core.Root
 import amf.core.parser.Annotations
 import amf.plugins.document.vocabularies.model.document.DialectInstanceLibrary
 
-class DialectInstanceLibraryParser(root: Root)(implicit override val ctx: DialectInstanceContext) extends DialectInstanceParser(root) {
+class DialectInstanceLibraryParser(root: Root)(implicit override val ctx: DialectInstanceContext)
+    extends DialectInstanceParser(root) {
 
-  def parse(): Option[DialectInstanceLibrary] = {
+  def parse(): DialectInstanceLibrary = {
     val dialectInstance: DialectInstanceLibrary = DialectInstanceLibrary(Annotations(map))
       .withLocation(root.location)
       .withId(root.location)
@@ -30,6 +31,6 @@ class DialectInstanceLibraryParser(root: Root)(implicit override val ctx: Dialec
     // resolve unresolved references
     ctx.futureDeclarations.resolve()
 
-    Some(dialectInstance)
+    dialectInstance
   }
 }

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/DialectInstancePatchParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/DialectInstancePatchParser.scala
@@ -6,17 +6,14 @@ import amf.validation.DialectValidations.DialectError
 import org.yaml.model.YType
 import amf.core.parser._
 
-class DialectInstancePatchParser(root: Root)(implicit override val ctx: DialectInstanceContext) extends DialectInstanceParser(root) {
+class DialectInstancePatchParser(root: Root)(implicit override val ctx: DialectInstanceContext)
+    extends DialectInstanceParser(root) {
 
-  def parse(): Option[DialectInstancePatch] = {
-    parseDocument() match {
-      case Some(dialectInstance) =>
-        val patch = DialectInstancePatch(dialectInstance.fields, dialectInstance.annotations)
-        patch.withId(dialectInstance.id)
-        Some(checkTarget(patch))
-      case _ =>
-        None
-    }
+  def parse(): DialectInstancePatch = {
+    val dialectInstance = parseDocument()
+    val patch           = DialectInstancePatch(dialectInstance.fields, dialectInstance.annotations)
+    patch.withId(dialectInstance.id)
+    checkTarget(patch)
   }
 
   private def checkTarget(patch: DialectInstancePatch): DialectInstancePatch = {

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/JsonPointerResolver.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/parser/instances/JsonPointerResolver.scala
@@ -15,7 +15,7 @@ trait JsonPointerResolver extends NodeMappableHelper with PlatformSecrets with B
   val root: Root
   implicit val ctx: DialectInstanceContext
 
-  protected def resolveJSONPointer(map: YMap, mapping: NodeMappable, id: String): Option[DialectDomainElement] = {
+  protected def resolveJSONPointer(map: YMap, mapping: NodeMappable, id: String): DialectDomainElement = {
     val mappingIds = allNodeMappingIds(mapping)
     val entry      = map.key("$ref").get
     val pointer    = entry.value.as[String]
@@ -37,10 +37,10 @@ trait JsonPointerResolver extends NodeMappableHelper with PlatformSecrets with B
         linkedNode.unresolved(fullPointer, map)
         linkedNode
       }
-    } orElse {
+    } getOrElse {
       val linkedNode = DialectDomainElement(map).withId(id).withInstanceTypes(Seq(mapping.id))
       linkedNode.unresolved(fullPointer, map)
-      Some(linkedNode)
+      linkedNode
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val workspaceDirectory: File =
     case _       => Path.userHome / "mulesoft"
   }
 
-val amfCoreVersion = "4.1.194"
+val amfCoreVersion = "4.1.195"
 
 lazy val amfCoreJVMRef = ProjectRef(workspaceDirectory / "amf-core", "coreJVM")
 lazy val amfCoreJSRef  = ProjectRef(workspaceDirectory / "amf-core", "coreJS")


### PR DESCRIPTION
Had to make changes in DialectInstanceParsers as all of them returned Option[BaseUnit].
More specifically:

- DialectInstanceFragmentParser -> parseEncodedFragment
- DialectInstanceParser -> parseEncoded

Both methods now return a DialectDomainElement, handling errors in the dialect with a violation and returning an empty node.