### PR TITLE
APIMF-2879: register pipelines in AMFConfiguration

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
@@ -4,13 +4,16 @@ import amf.client.remod.amfcore.config._
 import amf.client.remod.amfcore.plugins.AMFPlugin
 import amf.client.remod.amfcore.plugins.parse.AMFParsePlugin
 import amf.client.remod.amfcore.registry.AMFRegistry
+import amf.client.remod.amfcore.resolution.TransformationPipeline
 import amf.client.remod.{AMFGraphConfiguration, AMFResult, ErrorHandlerProvider}
+import amf.core.resolution.pipelines.ResolutionPipeline
 import amf.core.validation.core.ValidationProfile
 import amf.internal.reference.UnitCache
 import amf.internal.resource.ResourceLoader
-import amf.plugins.document.graph.AMFGraphParsePlugin
+import amf.plugins.document.graph.{AMFGraphParsePlugin, AMFGraphRenderPlugin}
 import amf.plugins.document.vocabularies.model.document.{Dialect, DialectInstance, DialectInstanceUnit}
-import amf.plugins.document.vocabularies.{AMLInstancePlugin, AMLParsePlugin}
+import amf.plugins.document.vocabularies.resolution.pipelines.DefaultAMLTransformationPipeline
+import amf.plugins.document.vocabularies.{AMLInstancePlugin, AMLParsePlugin, AMLRenderPlugin}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -48,6 +51,12 @@ private[amf] class AMLConfiguration(override private[amf] val resolvers: AMFReso
 
   override def withPlugins(plugins: List[AMFPlugin[_]]): AMLConfiguration =
     super.withPlugins(plugins).asInstanceOf[AMLConfiguration]
+  
+  override def withTransformationPipeline(name: String, pipeline: ResolutionPipeline): AMLConfiguration = 
+    super.withTransformationPipeline(name, pipeline).asInstanceOf[AMLConfiguration]
+
+  override def withTransformationPipelines(pipelines: Map[String, ResolutionPipeline]): AMLConfiguration = 
+    super.withTransformationPipelines(pipelines).asInstanceOf[AMLConfiguration]
 
   override def withValidationProfile(profile: ValidationProfile): AMLConfiguration =
     super.withValidationProfile(profile).asInstanceOf[AMLConfiguration]
@@ -97,6 +106,8 @@ private[amf] object AMLConfiguration {
         environment.registry,
         environment.logger,
         environment.listeners,
-        environment.options).withPlugins(List(AMLParsePlugin, AMFGraphParsePlugin)).asInstanceOf[AMLConfiguration]
+        environment.options)
+      .withPlugins(List(AMLParsePlugin, AMLRenderPlugin))
+      .withTransformationPipeline(TransformationPipeline.DEFAULT, new DefaultAMLTransformationPipeline())
   }
 }

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/AMLPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/AMLPlugin.scala
@@ -36,6 +36,7 @@ import amf.plugins.document.vocabularies.parser.instances._
 import amf.plugins.document.vocabularies.parser.vocabularies.{VocabulariesParser, VocabularyContext}
 import amf.plugins.document.vocabularies.plugin.headers._
 import amf.plugins.document.vocabularies.resolution.pipelines.{
+  DefaultAMLTransformationPipeline,
   DialectInstancePatchResolutionPipeline,
   DialectInstanceResolutionPipeline,
   DialectResolutionPipeline
@@ -100,21 +101,10 @@ trait AMLPlugin
         "json-pointer-ref" -> JsonPointerRef
     )
 
-  /**
-    * Resolves the provided base unit model, according to the semantics of the domain of the document
-    */
-  override def resolve(unit: BaseUnit,
-                       errorHandler: ErrorHandler,
-                       pipelineId: String = ResolutionPipeline.DEFAULT_PIPELINE): BaseUnit =
-    unit match {
-      case patch: DialectInstancePatch =>
-        new DialectInstancePatchResolutionPipeline(errorHandler).resolve(patch)
-      case dialect: Dialect =>
-        new DialectResolutionPipeline(errorHandler).resolve(dialect)
-      case dialect: DialectInstance =>
-        new DialectInstanceResolutionPipeline(errorHandler).resolve(dialect)
-      case _ => unit
-    }
+  override val pipelines: Map[String, ResolutionPipeline] = Map(
+      ResolutionPipeline.DEFAULT_PIPELINE -> new DefaultAMLTransformationPipeline(),
+      ResolutionPipeline.EDITING_PIPELINE -> new DefaultAMLTransformationPipeline() // hack to maintain compatibility with legacy behaviour
+  )
 
   /**
     * List of media types used to encode serialisations of

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/AMLValidator.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/AMLValidator.scala
@@ -3,6 +3,7 @@ package amf.plugins.document.vocabularies
 import amf.client.remod.amfcore.plugins.validate.ValidationResult
 import amf.{ProfileName, RamlProfile}
 import amf.core.model.document.BaseUnit
+import amf.core.remote.Aml
 import amf.core.services.{RuntimeValidator, ValidationOptions}
 import amf.core.validation.{AMFValidationReport, EffectiveValidations, ShaclReportAdaptation}
 import amf.core.validation.core.ValidationProfile
@@ -18,8 +19,8 @@ class AMLValidator(registry: DialectsRegistry) extends ShaclReportAdaptation {
 
     baseUnit match {
       case dialectInstance: DialectInstanceUnit =>
-
-        val resolvedModel = new DialectInstanceResolutionPipeline(baseUnit.errorHandler()).resolve(dialectInstance)
+        val resolvedModel =
+          new DialectInstanceResolutionPipeline().transform(dialectInstance, Aml.name, baseUnit.errorHandler())
         val dependenciesValidations = computeValidationProfilesOfDependencies(dialectInstance)
 
         for {

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectValidationProfileComputation.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectValidationProfileComputation.scala
@@ -1,5 +1,6 @@
 package amf.plugins.document.vocabularies
 
+import amf.core.remote.Aml
 import amf.core.validation.core.ValidationProfile
 import amf.plugins.document.vocabularies.model.document.Dialect
 import amf.plugins.document.vocabularies.resolution.pipelines.DialectResolutionPipeline
@@ -12,7 +13,7 @@ object DialectValidationProfileComputation {
     registry.validations.get(header) match {
       case Some(profile) => profile
       case _ =>
-        val resolvedDialect = new DialectResolutionPipeline(dialect.errorHandler()).resolve(dialect)
+        val resolvedDialect = new DialectResolutionPipeline().transform(dialect, Aml.name, dialect.errorHandler())
         val profile         = new AMFDialectValidations(resolvedDialect).profile()
         registry.validations += (header -> profile)
         profile

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
@@ -71,7 +71,7 @@ class DialectsRegistry extends AMFDomainEntityResolver with PlatformSecrets {
   }
 
   private def resolveDialect(dialect: Dialect) = {
-    val solved = new DialectResolutionPipeline(DefaultErrorHandler()).resolve(dialect)
+    val solved = new DialectResolutionPipeline().transform(dialect, Aml.name, DefaultErrorHandler())
     dialect.allHeaders foreach { header =>
       map += (header -> solved)
     }

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DefaultAMLTransformationPipeline.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DefaultAMLTransformationPipeline.scala
@@ -1,0 +1,21 @@
+package amf.plugins.document.vocabularies.resolution.pipelines
+
+import amf.core.errorhandling.ErrorHandler
+import amf.core.model.document.BaseUnit
+import amf.core.resolution.pipelines.{BasicResolutionPipeline, ResolutionPipeline}
+import amf.core.resolution.stages.ResolutionStage
+import amf.plugins.document.vocabularies.model.document.{Dialect, DialectInstance, DialectInstancePatch}
+
+class DefaultAMLTransformationPipeline() extends ResolutionPipeline {
+
+  override def steps(model: BaseUnit, sourceVendor: String)(
+      implicit errorHandler: ErrorHandler): Seq[ResolutionStage] = {
+    model match {
+      case _: DialectInstancePatch => new DialectInstancePatchResolutionPipeline().steps(model, sourceVendor)
+      case _: Dialect              => new DialectResolutionPipeline().steps(model, sourceVendor)
+      case _: DialectInstance      => new DialectInstanceResolutionPipeline().steps(model, sourceVendor)
+      case _                       => new BasicResolutionPipeline().steps(model, sourceVendor)
+    }
+  }
+
+}

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DialectInstancePatchResolutionPipeline.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DialectInstancePatchResolutionPipeline.scala
@@ -1,5 +1,6 @@
 package amf.plugins.document.vocabularies.resolution.pipelines
 import amf.core.errorhandling.ErrorHandler
+import amf.core.model.document.BaseUnit
 import amf.core.resolution.pipelines.ResolutionPipeline
 import amf.core.resolution.stages.{CleanReferencesStage, DeclarationsRemovalStage, ResolutionStage}
 import amf.plugins.document.vocabularies.resolution.stages.{
@@ -8,15 +9,15 @@ import amf.plugins.document.vocabularies.resolution.stages.{
 }
 import amf.{AmfProfile, ProfileName}
 
-class DialectInstancePatchResolutionPipeline(override val eh: ErrorHandler) extends ResolutionPipeline(eh) {
+class DialectInstancePatchResolutionPipeline() extends ResolutionPipeline() {
 
-  override val steps: Seq[ResolutionStage] = Seq(
-      new DialectInstanceReferencesResolutionStage(),
-      new DialectPatchApplicationStage(),
-      new CleanReferencesStage(),
-      new DeclarationsRemovalStage()
-  )
-
-  override def profileName: ProfileName = AmfProfile
+  override def steps(model: BaseUnit, sourceVendor: String)(
+      implicit errorHandler: ErrorHandler): Seq[ResolutionStage] =
+    Seq(
+        new DialectInstanceReferencesResolutionStage(),
+        new DialectPatchApplicationStage(),
+        new CleanReferencesStage(),
+        new DeclarationsRemovalStage()
+    )
 
 }

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DialectInstanceResolutionPipeline.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DialectInstanceResolutionPipeline.scala
@@ -1,17 +1,19 @@
 package amf.plugins.document.vocabularies.resolution.pipelines
 
 import amf.core.errorhandling.ErrorHandler
+import amf.core.model.document.BaseUnit
 import amf.core.resolution.pipelines.ResolutionPipeline
 import amf.core.resolution.stages.{CleanReferencesStage, DeclarationsRemovalStage, ResolutionStage}
 import amf.plugins.document.vocabularies.resolution.stages.DialectInstanceReferencesResolutionStage
 import amf.{AmfProfile, ProfileName}
 
-class DialectInstanceResolutionPipeline(override val eh: ErrorHandler) extends ResolutionPipeline(eh) {
+class DialectInstanceResolutionPipeline() extends ResolutionPipeline() {
 
-  override val steps: Seq[ResolutionStage] = Seq(
-      new DialectInstanceReferencesResolutionStage(),
-      new CleanReferencesStage(),
-      new DeclarationsRemovalStage()
-  )
-  override def profileName: ProfileName = AmfProfile
+  override def steps(model: BaseUnit, sourceVendor: String)(
+      implicit errorHandler: ErrorHandler): Seq[ResolutionStage] =
+    Seq(
+        new DialectInstanceReferencesResolutionStage(),
+        new CleanReferencesStage(),
+        new DeclarationsRemovalStage()
+    )
 }

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DialectResolutionPipeline.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/resolution/pipelines/DialectResolutionPipeline.scala
@@ -1,14 +1,18 @@
 package amf.plugins.document.vocabularies.resolution.pipelines
 
 import amf.core.errorhandling.ErrorHandler
+import amf.core.model.document.BaseUnit
 import amf.core.resolution.pipelines.ResolutionPipeline
 import amf.core.resolution.stages.ResolutionStage
-import amf.plugins.document.vocabularies.resolution.stages.{DialectNodeExtensionStage, DialectReferencesResolutionStage}
+import amf.plugins.document.vocabularies.resolution.stages.{
+  DialectNodeExtensionStage,
+  DialectReferencesResolutionStage
+}
 import amf.{AmfProfile, ProfileName}
 
-class DialectResolutionPipeline(override val eh: ErrorHandler) extends ResolutionPipeline(eh) {
+class DialectResolutionPipeline() extends ResolutionPipeline() {
 
-  override val steps: Seq[ResolutionStage] =
+  override def steps(model: BaseUnit, sourceVendor: String)(
+      implicit errorHandler: ErrorHandler): Seq[ResolutionStage] =
     Seq(new DialectReferencesResolutionStage(), new DialectNodeExtensionStage())
-  override def profileName: ProfileName = AmfProfile
 }

--- a/amf-aml/shared/src/test/scala/amf/dialects/DialectProductionTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/DialectProductionTest.scala
@@ -5,10 +5,10 @@ import amf.core.emitter.RenderOptions
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.io.FunSuiteCycleTests
 import amf.core.model.document.BaseUnit
-import amf.core.registries.AMFPluginsRegistry
 import amf.core.remote._
 import amf.core.{AMFCompiler, CompilerContextBuilder}
-import amf.plugins.document.vocabularies.AMLPlugin
+import amf.core.resolution.pipelines.ResolutionPipeline
+import amf.core.services.RuntimeResolver
 import org.scalatest.Assertion
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -187,7 +187,7 @@ class DialectProductionResolutionTest extends FunSuiteCycleTests with DialectIns
   override implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
   override def transform(unit: BaseUnit, config: CycleConfig): BaseUnit =
-    AMLPlugin().resolve(unit, UnhandledErrorHandler)
+    RuntimeResolver.resolve(Vendor.AML.name, unit, ResolutionPipeline.DEFAULT_PIPELINE, UnhandledErrorHandler)
 
   val basePath = "amf-aml/shared/src/test/resources/vocabularies2/production/"
 

--- a/amf-aml/shared/src/test/scala/amf/dialects/DialectTests.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/DialectTests.scala
@@ -7,6 +7,8 @@ import amf.core.io.{FileAssertionTest, MultiJsonldAsyncFunSuite}
 import amf.core.model.document.BaseUnit
 import amf.core.remote.Syntax.Syntax
 import amf.core.remote._
+import amf.core.resolution.pipelines.ResolutionPipeline
+import amf.core.services.RuntimeResolver
 import amf.core.{AMFCompiler, AMFSerializer, CompilerContextBuilder}
 import amf.plugins.document.graph.AMFGraphPlugin
 import amf.plugins.document.vocabularies.AMLPlugin
@@ -35,7 +37,9 @@ trait DialectTests
       new CompilerContextBuilder(s"file://$directory/$dialect", platform, DefaultParserErrorHandler.withRun()).build()
     for {
       dialect <- new AMFCompiler(context, None, Some(Aml.name)).build()
-      _       <- Future.successful { AMLPlugin().resolve(dialect, UnhandledErrorHandler) }
+      _ <- Future.successful {
+        RuntimeResolver.resolve(Vendor.AML.name, dialect, ResolutionPipeline.DEFAULT_PIPELINE, UnhandledErrorHandler)
+      }
       res <- cycle(source,
                    golden,
                    hint,
@@ -58,7 +62,9 @@ trait DialectTests
                                                             DefaultParserErrorHandler.withRun()).build(),
                                  None,
                                  Some(Aml.name)).build()
-      _ <- Future.successful { AMLPlugin().resolve(dialect, UnhandledErrorHandler) }
+      _ <- Future.successful {
+        RuntimeResolver.resolve(Vendor.AML.name, dialect, ResolutionPipeline.DEFAULT_PIPELINE, UnhandledErrorHandler)
+      }
       b <- new AMFCompiler(new CompilerContextBuilder(s"file://$directory/$source",
                                                       platform,
                                                       DefaultParserErrorHandler.withRun()).build(),
@@ -107,5 +113,5 @@ trait DialectTests
 
 abstract class DialectInstanceResolutionCycleTests extends DialectTests {
   override def transform(unit: BaseUnit): BaseUnit =
-    AMLPlugin().resolve(unit, UnhandledErrorHandler)
+    RuntimeResolver.resolve(Vendor.AML.name, unit, ResolutionPipeline.DEFAULT_PIPELINE, UnhandledErrorHandler)
 }

--- a/amf-aml/shared/src/test/scala/amf/dialects/DialectsResolutionTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/DialectsResolutionTest.scala
@@ -2,15 +2,17 @@ package amf.dialects
 
 import amf.core.errorhandling.UnhandledErrorHandler
 import amf.core.model.document.BaseUnit
-import amf.core.remote.{Amf, Aml, VocabularyYamlHint}
+import amf.core.remote.{Amf, Aml, Vendor, VocabularyYamlHint}
 import amf.core.io.FunSuiteCycleTests
+import amf.core.resolution.pipelines.ResolutionPipeline
+import amf.core.services.RuntimeResolver
 import amf.plugins.document.vocabularies.AMLPlugin
 
 import scala.concurrent.ExecutionContext
 
 abstract class DialectResolutionCycleTests extends FunSuiteCycleTests {
   override def transform(unit: BaseUnit, config: CycleConfig): BaseUnit =
-    AMLPlugin().resolve(unit, UnhandledErrorHandler)
+    RuntimeResolver.resolve(Vendor.AML.name, unit, ResolutionPipeline.DEFAULT_PIPELINE, UnhandledErrorHandler)
 }
 
 class DialectsResolutionTest extends DialectResolutionCycleTests {


### PR DESCRIPTION
- moved error handler into transform method parameter
- unified aml and graph pipelines into default pipeline

depends on https://github.com/aml-org/amf-core/pull/207