### PR TITLE
Apimf 3050/empty type discriminator

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/model/domain/NodeWithDiscriminator.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/model/domain/NodeWithDiscriminator.scala
@@ -1,6 +1,7 @@
 package amf.plugins.document.vocabularies.model.domain
 import amf.core.model.StrField
-import amf.core.model.domain.DomainElement
+import amf.core.model.domain.{AmfScalar, DomainElement}
+import amf.core.parser.Annotations
 import amf.plugins.document.vocabularies.metamodel.domain.UnionNodeMappingModel._
 
 trait NodeWithDiscriminator[T] extends DomainElement {
@@ -11,12 +12,17 @@ trait NodeWithDiscriminator[T] extends DomainElement {
       disambiguator.split(",").foldLeft(Map[String, String]()) {
         case (acc, typeMapping) =>
           val pair = typeMapping.split("->")
-          acc + (pair(1) -> pair(0))
+          acc + (pair.lift(1).getOrElse("") -> pair(0))
       }
     }.orNull
 
   def withObjectRange(range: Seq[String]): T     = set(ObjectRange, range).asInstanceOf[T]
   def withTypeDiscriminatorName(name: String): T = set(TypeDiscriminatorName, name).asInstanceOf[T]
-  def withTypeDiscriminator(typesMapping: Map[String, String]): T =
-    set(TypeDiscriminator, typesMapping.map { case (a, b) => s"$a->$b" }.mkString(",")).asInstanceOf[T]
+  def withTypeDiscriminator(typesMapping: Map[String, String],
+                            entryAnnotations: Annotations = Annotations(),
+                            valueAnnotations: Annotations = Annotations()): T =
+    set(TypeDiscriminator,
+        AmfScalar(typesMapping.map { case (a, b) => s"$a->$b" }.mkString(","), valueAnnotations),
+        entryAnnotations)
+      .asInstanceOf[T]
 }

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.expanded.jsonld
@@ -1,0 +1,423 @@
+[
+  {
+    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/meta#Dialect",
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/core#name": [
+      {
+        "@value": "Test Unions"
+      }
+    ],
+    "http://a.ml/vocabularies/core#version": [
+      {
+        "@value": "1.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#location": [
+      {
+        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml"
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "3.0.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document-source-maps#sources": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map",
+        "@type": [
+          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        ],
+        "http://a.ml/vocabularies/document-source-maps#lexical": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_2",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/core#name"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(3,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/core#version"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(3,0)-(5,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_1",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(23,0)]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A",
+        "@type": [
+          "http://a.ml/vocabularies/meta#NodeMapping",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "A"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text",
+            "@type": [
+              "http://a.ml/vocabularies/meta#NodePropertyMapping",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "text"
+              }
+            ],
+            "http://www.w3.org/ns/shacl#datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map/lexical/element_1",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(9,0)-(11,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(8,6)-(8,10)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(6,2)-(6,3)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/ns/shacl#property"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(7,4)-(11,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(6,2)-(11,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B",
+        "@type": [
+          "http://a.ml/vocabularies/meta#NodeMapping",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "B"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text",
+            "@type": [
+              "http://a.ml/vocabularies/meta#NodePropertyMapping",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "text"
+              }
+            ],
+            "http://www.w3.org/ns/shacl#datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map/lexical/element_1",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(14,0)-(17,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(13,6)-(13,10)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(11,2)-(11,3)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/ns/shacl#property"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(12,4)-(17,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(11,2)-(17,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode",
+        "@type": [
+          "http://a.ml/vocabularies/meta#UnionNodeMapping",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "RootNode"
+          }
+        ],
+        "http://a.ml/vocabularies/meta#typeDiscriminatorMap": [
+          {
+            "@value": ""
+          }
+        ],
+        "http://a.ml/vocabularies/meta#typeDiscriminatorName": [
+          {
+            "@value": "kind"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#node": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/list",
+            "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
+            "http://www.w3.org/2000/01/rdf-schema#_1": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A"
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_2": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_3",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorMap"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(22,4)-(23,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(17,2)-(17,10)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorName"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(21,4)-(22,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(17,2)-(23,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.flattened.jsonld
@@ -1,0 +1,322 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/meta#Dialect",
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/core#name": "Test Unions",
+      "http://a.ml/vocabularies/core#version": "1.0",
+      "http://a.ml/vocabularies/document#location": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml",
+      "http://a.ml/vocabularies/document#version": "3.0.0",
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodeMapping",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "A",
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodeMapping",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "B",
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode",
+      "@type": [
+        "http://a.ml/vocabularies/meta#UnionNodeMapping",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "RootNode",
+      "http://a.ml/vocabularies/meta#typeDiscriminatorMap": "",
+      "http://a.ml/vocabularies/meta#typeDiscriminatorName": "kind",
+      "http://www.w3.org/ns/shacl#node": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/list"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodePropertyMapping",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "text",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodePropertyMapping",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "text",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/list",
+      "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
+      "http://www.w3.org/2000/01/rdf-schema#_1": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A"
+      },
+      "http://www.w3.org/2000/01/rdf-schema#_2": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B"
+      }
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(3,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(5,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(23,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(6,3)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(11,3)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,4)-(17,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(17,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(22,4)-(23,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(17,2)-(17,10)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorName",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(21,4)-(22,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/RootNode",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(17,2)-(23,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,0)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/A/property/text/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(8,6)-(8,10)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(14,0)-(17,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml#/declarations/B/property/text/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(13,6)-(13,10)]"
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-field.yaml
@@ -1,0 +1,22 @@
+#%Dialect 1.0
+dialect: Test Unions
+version: 1.0
+
+nodeMappings:
+  A:
+    mapping:
+      text:
+        propertyTerm: vocab.text
+        range: string
+  B:
+    mapping:
+      text:
+        propertyTerm: vocab.text
+        range: string
+
+  RootNode:
+    union:
+      - A
+      - B
+    typeDiscriminatorName: kind
+    typeDiscriminator:

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.expanded.jsonld
@@ -1,0 +1,423 @@
+[
+  {
+    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml",
+    "@type": [
+      "http://a.ml/vocabularies/meta#Dialect",
+      "http://a.ml/vocabularies/document#Document",
+      "http://a.ml/vocabularies/document#Fragment",
+      "http://a.ml/vocabularies/document#Module",
+      "http://a.ml/vocabularies/document#Unit"
+    ],
+    "http://a.ml/vocabularies/core#name": [
+      {
+        "@value": "Test Unions"
+      }
+    ],
+    "http://a.ml/vocabularies/core#version": [
+      {
+        "@value": "1.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#location": [
+      {
+        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml"
+      }
+    ],
+    "http://a.ml/vocabularies/document#version": [
+      {
+        "@value": "3.0.0"
+      }
+    ],
+    "http://a.ml/vocabularies/document#root": [
+      {
+        "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document-source-maps#sources": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map",
+        "@type": [
+          "http://a.ml/vocabularies/document-source-maps#SourceMap"
+        ],
+        "http://a.ml/vocabularies/document-source-maps#lexical": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_2",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/core#name"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(3,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_0",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "http://a.ml/vocabularies/core#version"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(3,0)-(5,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_1",
+            "http://a.ml/vocabularies/document-source-maps#element": [
+              {
+                "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#value": [
+              {
+                "@value": "[(2,0)-(23,12)]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "http://a.ml/vocabularies/document#declares": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A",
+        "@type": [
+          "http://a.ml/vocabularies/meta#NodeMapping",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "A"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text",
+            "@type": [
+              "http://a.ml/vocabularies/meta#NodePropertyMapping",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "text"
+              }
+            ],
+            "http://www.w3.org/ns/shacl#datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map/lexical/element_1",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(9,0)-(11,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(8,6)-(8,10)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(6,2)-(6,3)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/ns/shacl#property"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(7,4)-(11,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(6,2)-(11,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B",
+        "@type": [
+          "http://a.ml/vocabularies/meta#NodeMapping",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "B"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#property": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text",
+            "@type": [
+              "http://a.ml/vocabularies/meta#NodePropertyMapping",
+              "http://a.ml/vocabularies/document#DomainElement"
+            ],
+            "http://a.ml/vocabularies/core#name": [
+              {
+                "@value": "text"
+              }
+            ],
+            "http://www.w3.org/ns/shacl#datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "http://a.ml/vocabularies/document-source-maps#sources": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map",
+                "@type": [
+                  "http://a.ml/vocabularies/document-source-maps#SourceMap"
+                ],
+                "http://a.ml/vocabularies/document-source-maps#lexical": [
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map/lexical/element_1",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(14,0)-(17,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map/lexical/element_0",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(13,6)-(13,10)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(11,2)-(11,3)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://www.w3.org/ns/shacl#property"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(12,4)-(17,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(11,2)-(17,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode",
+        "@type": [
+          "http://a.ml/vocabularies/meta#UnionNodeMapping",
+          "http://www.w3.org/ns/shacl#Shape",
+          "http://a.ml/vocabularies/document#DomainElement"
+        ],
+        "http://a.ml/vocabularies/core#name": [
+          {
+            "@value": "RootNode"
+          }
+        ],
+        "http://a.ml/vocabularies/meta#typeDiscriminatorMap": [
+          {
+            "@value": ""
+          }
+        ],
+        "http://a.ml/vocabularies/meta#typeDiscriminatorName": [
+          {
+            "@value": "kind"
+          }
+        ],
+        "http://www.w3.org/ns/shacl#node": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/list",
+            "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
+            "http://www.w3.org/2000/01/rdf-schema#_1": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A"
+              }
+            ],
+            "http://www.w3.org/2000/01/rdf-schema#_2": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B"
+              }
+            ]
+          }
+        ],
+        "http://a.ml/vocabularies/document-source-maps#sources": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map",
+            "@type": [
+              "http://a.ml/vocabularies/document-source-maps#SourceMap"
+            ],
+            "http://a.ml/vocabularies/document-source-maps#lexical": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_3",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorMap"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(23,0)-(23,12)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_1",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/core#name"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(17,2)-(17,10)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_0",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorName"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(21,4)-(22,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_2",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(17,2)-(23,12)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.expanded.jsonld
@@ -371,7 +371,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
-                    "@value": "[(23,0)-(23,12)]"
+                    "@value": "[(22,4)-(23,12)]"
                   }
                 ]
               },

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.flattened.jsonld
@@ -1,0 +1,322 @@
+{
+  "@graph": [
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml",
+      "http://a.ml/vocabularies/document#declares": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode"
+        }
+      ],
+      "@type": [
+        "http://a.ml/vocabularies/meta#Dialect",
+        "http://a.ml/vocabularies/document#Document",
+        "http://a.ml/vocabularies/document#Fragment",
+        "http://a.ml/vocabularies/document#Module",
+        "http://a.ml/vocabularies/document#Unit"
+      ],
+      "http://a.ml/vocabularies/core#name": "Test Unions",
+      "http://a.ml/vocabularies/core#version": "1.0",
+      "http://a.ml/vocabularies/document#location": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml",
+      "http://a.ml/vocabularies/document#version": "3.0.0",
+      "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodeMapping",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "A",
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodeMapping",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "B",
+      "http://www.w3.org/ns/shacl#property": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode",
+      "@type": [
+        "http://a.ml/vocabularies/meta#UnionNodeMapping",
+        "http://www.w3.org/ns/shacl#Shape",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "RootNode",
+      "http://a.ml/vocabularies/meta#typeDiscriminatorMap": "",
+      "http://a.ml/vocabularies/meta#typeDiscriminatorName": "kind",
+      "http://www.w3.org/ns/shacl#node": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/list"
+      },
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodePropertyMapping",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "text",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text",
+      "@type": [
+        "http://a.ml/vocabularies/meta#NodePropertyMapping",
+        "http://a.ml/vocabularies/document#DomainElement"
+      ],
+      "http://a.ml/vocabularies/core#name": "text",
+      "http://www.w3.org/ns/shacl#datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "http://a.ml/vocabularies/document-source-maps#sources": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_2"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/list",
+      "@type": "http://www.w3.org/2000/01/rdf-schema#Seq",
+      "http://www.w3.org/2000/01/rdf-schema#_1": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A"
+      },
+      "http://www.w3.org/2000/01/rdf-schema#_2": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B"
+      }
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_0"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(3,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#version",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(3,0)-(5,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(2,0)-(23,12)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(6,3)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(7,4)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(6,2)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map",
+      "@type": [
+        "http://a.ml/vocabularies/document-source-maps#SourceMap"
+      ],
+      "http://a.ml/vocabularies/document-source-maps#lexical": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(11,3)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://www.w3.org/ns/shacl#property",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(12,4)-(17,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,2)-(17,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,0)-(23,12)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(17,2)-(17,10)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorName",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(21,4)-(22,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(17,2)-(23,12)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(9,0)-(11,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/A/property/text/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(8,6)-(8,10)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(14,0)-(17,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/B/property/text/source-map/lexical/element_0",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(13,6)-(13,10)]"
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.flattened.jsonld
@@ -281,7 +281,7 @@
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(23,0)-(23,12)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(22,4)-(23,12)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml#/declarations/RootNode/source-map/lexical/element_1",

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/empty-type-discriminator-value.yaml
@@ -1,0 +1,23 @@
+#%Dialect 1.0
+dialect: Test Unions
+version: 1.0
+
+nodeMappings:
+  A:
+    mapping:
+      text:
+        propertyTerm: vocab.text
+        range: string
+  B:
+    mapping:
+      text:
+        propertyTerm: vocab.text
+        range: string
+
+  RootNode:
+    union:
+      - A
+      - B
+    typeDiscriminatorName: kind
+    typeDiscriminator:
+      TypeA:

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.expanded.jsonld
@@ -373,7 +373,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(11,0)-(13,0)]"
+                        "@value": "[(10,8)-(13,0)]"
                       }
                     ]
                   },

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.expanded.jsonld
@@ -365,7 +365,20 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_2",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_3",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorMap"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(11,0)-(13,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "http://a.ml/vocabularies/core#name"
@@ -391,7 +404,7 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_1",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
                         "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za"

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.flattened.jsonld
@@ -442,13 +442,16 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_2"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_1"
         },
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_1"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_2"
         }
       ]
     },
@@ -526,7 +529,12 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(23,2)-(29,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_2",
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(11,0)-(13,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(8,6)-(8,8)]"
     },
@@ -536,7 +544,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(9,8)-(10,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_1",
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za",
       "http://a.ml/vocabularies/document-source-maps#value": "[(9,0)-(17,0)]"
     },

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.flattened.jsonld
@@ -531,7 +531,7 @@
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(11,0)-(13,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(10,8)-(13,0)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml#/declarations/nodeB/property/za/source-map/lexical/element_1",

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example12.yaml
@@ -7,13 +7,13 @@ nodeMappings:
     mapping:
       za:
         typeDiscriminatorName: type
+        typeDiscriminator:
+          TypeA: nodeA
+          TypeB: nodeC
         propertyTerm: v2.a
         range:
           - nodeA
           - nodeC
-        typeDiscriminator:
-          TypeA: nodeA
-          TypeB: nodeC
   nodeA:
     classTerm: v2.A
     mapping:

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.expanded.jsonld
@@ -669,7 +669,20 @@
             ],
             "http://a.ml/vocabularies/document-source-maps#lexical": [
               {
-                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_2",
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_3",
+                "http://a.ml/vocabularies/document-source-maps#element": [
+                  {
+                    "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorMap"
+                  }
+                ],
+                "http://a.ml/vocabularies/document-source-maps#value": [
+                  {
+                    "@value": "[(24,0)-(26,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_1",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
                     "@value": "http://a.ml/vocabularies/core#name"
@@ -695,7 +708,7 @@
                 ]
               },
               {
-                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_1",
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_2",
                 "http://a.ml/vocabularies/document-source-maps#element": [
                   {
                     "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode"

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.expanded.jsonld
@@ -677,7 +677,7 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#value": [
                   {
-                    "@value": "[(24,0)-(26,0)]"
+                    "@value": "[(23,4)-(26,0)]"
                   }
                 ]
               },

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.flattened.jsonld
@@ -408,13 +408,16 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_2"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_3"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_1"
         },
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_1"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_2"
         }
       ]
     },
@@ -547,7 +550,12 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(14,2)-(21,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_2",
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(24,0)-(26,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_1",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
       "http://a.ml/vocabularies/document-source-maps#value": "[(21,2)-(21,11)]"
     },
@@ -557,7 +565,7 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(22,4)-(23,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_1",
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_2",
       "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode",
       "http://a.ml/vocabularies/document-source-maps#value": "[(21,2)-(29,0)]"
     },

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.flattened.jsonld
@@ -552,7 +552,7 @@
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_3",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(24,0)-(26,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(23,4)-(26,0)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml#/declarations/UnionNode/source-map/lexical/element_1",

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/example20.yaml
@@ -20,12 +20,12 @@ nodeMappings:
         range: string
   UnionNode:
     typeDiscriminatorName: lala
-    union:
-      - Local
-      - Declarations
     typeDiscriminator:
       local: Local
       decls: Declarations
+    union:
+      - Local
+      - Declarations
   Root:
     classTerm: v3.Root
     mapping:

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.report
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.report
@@ -1,0 +1,30 @@
+Model: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml
+Profile: Test Unions 1.0
+Conforms? false
+Number of results: 3
+
+Level: Violation
+
+- Source: http://a.ml/vocabularies/amf/aml#dialect-error
+  Message: Cannot find property term with alias vocab.text
+  Level: Violation
+  Target: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml#/declarations/A/property/text
+  Property: 
+  Position: Some(LexicalInformation([(9,22)-(9,32)]))
+  Location: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml
+
+- Source: http://a.ml/vocabularies/amf/aml#dialect-error
+  Message: Cannot find property term with alias vocab.text
+  Level: Violation
+  Target: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml#/declarations/B/property/text
+  Property: 
+  Position: Some(LexicalInformation([(14,22)-(14,32)]))
+  Location: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml
+
+- Source: http://a.ml/vocabularies/amf/aml#missing-node-mapping-range-term
+  Message: Cannot find property range term 
+  Level: Violation
+  Target: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml#/declarations/RootNode
+  Property: http://www.w3.org/ns/shacl#node
+  Position: Some(LexicalInformation([(23,0)-(23,12)]))
+  Location: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.report
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.report
@@ -26,5 +26,5 @@ Level: Violation
   Level: Violation
   Target: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml#/declarations/RootNode
   Property: http://www.w3.org/ns/shacl#node
-  Position: Some(LexicalInformation([(23,0)-(23,12)]))
+  Position: Some(LexicalInformation([(22,4)-(23,12)]))
   Location: file://amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/invalids/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml
@@ -1,0 +1,23 @@
+#%Dialect 1.0
+dialect: Test Unions
+version: 1.0
+
+nodeMappings:
+  A:
+    mapping:
+      text:
+        propertyTerm: vocab.text
+        range: string
+  B:
+    mapping:
+      text:
+        propertyTerm: vocab.text
+        range: string
+
+  RootNode:
+    union:
+      - A
+      - B
+    typeDiscriminatorName: kind
+    typeDiscriminator:
+      TypeA:

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.json
@@ -10693,28 +10693,28 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items/source-map/lexical/element_3",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items/source-map/lexical/element_4",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/meta#allowMultiple"
+                        "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorMap"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(340,8)-(343,0)]"
+                        "@value": "[(337,0)-(340,0)]"
                       }
                     ]
                   },
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items/source-map/lexical/element_1",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/core#name"
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(329,6)-(329,11)]"
+                        "@value": "[(330,0)-(343,0)]"
                       }
                     ]
                   },
@@ -10732,15 +10732,28 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items/source-map/lexical/element_2",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items"
+                        "@value": "http://a.ml/vocabularies/meta#allowMultiple"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(330,0)-(343,0)]"
+                        "@value": "[(340,8)-(343,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.yaml#/declarations/CollectionNode/property/items/source-map/lexical/element_3",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(329,6)-(329,11)]"
                       }
                     ]
                   }

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/streams/activity.json
@@ -10701,7 +10701,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(337,0)-(340,0)]"
+                        "@value": "[(336,8)-(340,0)]"
                       }
                     ]
                   },

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.expanded.jsonld
@@ -1117,7 +1117,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(62,0)-(65,0)]"
+                        "@value": "[(61,8)-(65,0)]"
                       }
                     ]
                   },
@@ -7158,7 +7158,7 @@
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(563,0)-(566,0)]"
+                        "@value": "[(562,8)-(566,0)]"
                       }
                     ]
                   },

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.expanded.jsonld
@@ -1109,28 +1109,28 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_3",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_4",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/meta#allowMultiple"
+                        "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorMap"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(60,8)-(61,0)]"
+                        "@value": "[(62,0)-(65,0)]"
                       }
                     ]
                   },
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_1",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/core#name"
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(53,6)-(53,25)]"
+                        "@value": "[(54,0)-(66,0)]"
                       }
                     ]
                   },
@@ -1148,15 +1148,28 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_2",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions"
+                        "@value": "http://a.ml/vocabularies/meta#allowMultiple"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(54,0)-(66,0)]"
+                        "@value": "[(60,8)-(61,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_3",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(53,6)-(53,25)]"
                       }
                     ]
                   }
@@ -7137,28 +7150,28 @@
                 ],
                 "http://a.ml/vocabularies/document-source-maps#lexical": [
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_3",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_4",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/meta#allowMultiple"
+                        "@value": "http://a.ml/vocabularies/meta#typeDiscriminatorMap"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(561,8)-(562,0)]"
+                        "@value": "[(563,0)-(566,0)]"
                       }
                     ]
                   },
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_1",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_2",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "http://a.ml/vocabularies/core#name"
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(554,6)-(554,14)]"
+                        "@value": "[(555,0)-(568,0)]"
                       }
                     ]
                   },
@@ -7176,15 +7189,28 @@
                     ]
                   },
                   {
-                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_2",
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_1",
                     "http://a.ml/vocabularies/document-source-maps#element": [
                       {
-                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security"
+                        "@value": "http://a.ml/vocabularies/meta#allowMultiple"
                       }
                     ],
                     "http://a.ml/vocabularies/document-source-maps#value": [
                       {
-                        "@value": "[(555,0)-(568,0)]"
+                        "@value": "[(561,8)-(562,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_3",
+                    "http://a.ml/vocabularies/document-source-maps#element": [
+                      {
+                        "@value": "http://a.ml/vocabularies/core#name"
+                      }
+                    ],
+                    "http://a.ml/vocabularies/document-source-maps#value": [
+                      {
+                        "@value": "[(554,6)-(554,14)]"
                       }
                     ]
                   }

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.flattened.jsonld
@@ -4784,16 +4784,19 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_3"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_4"
         },
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_1"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_2"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_3"
         }
       ]
     },
@@ -6406,16 +6409,19 @@
       ],
       "http://a.ml/vocabularies/document-source-maps#lexical": [
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_3"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_4"
         },
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_1"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_2"
         },
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_0"
         },
         {
-          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_2"
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_1"
+        },
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_3"
         }
       ]
     },
@@ -7449,14 +7455,14 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(24,0)-(27,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#allowMultiple",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(60,8)-(61,0)]"
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(62,0)-(65,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(53,6)-(53,25)]"
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(54,0)-(66,0)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_0",
@@ -7464,9 +7470,14 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(65,8)-(66,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(54,0)-(66,0)]"
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#allowMultiple",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(60,8)-(61,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(53,6)-(53,25)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/security/source-map/lexical/element_1",
@@ -8394,14 +8405,14 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(513,6)-(513,13)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_3",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#allowMultiple",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(561,8)-(562,0)]"
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_4",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(563,0)-(566,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_1",
-      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(554,6)-(554,14)]"
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_2",
+      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(555,0)-(568,0)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_0",
@@ -8409,9 +8420,14 @@
       "http://a.ml/vocabularies/document-source-maps#value": "[(566,8)-(568,0)]"
     },
     {
-      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_2",
-      "http://a.ml/vocabularies/document-source-maps#element": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(555,0)-(568,0)]"
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_1",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#allowMultiple",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(561,8)-(562,0)]"
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_3",
+      "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/core#name",
+      "http://a.ml/vocabularies/document-source-maps#value": "[(554,6)-(554,14)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/schemes/source-map/lexical/element_3",

--- a/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.flattened.jsonld
@@ -7457,7 +7457,7 @@
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(62,0)-(65,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(61,8)-(65,0)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/WebAPIObject/property/securityDefinitions/source-map/lexical/element_2",
@@ -8407,7 +8407,7 @@
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_4",
       "http://a.ml/vocabularies/document-source-maps#element": "http://a.ml/vocabularies/meta#typeDiscriminatorMap",
-      "http://a.ml/vocabularies/document-source-maps#value": "[(563,0)-(566,0)]"
+      "http://a.ml/vocabularies/document-source-maps#value": "[(562,8)-(566,0)]"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/production/system2/dialectex2.yaml#/declarations/OperationObject/property/security/source-map/lexical/element_2",

--- a/amf-aml/shared/src/test/scala/amf/dialects/DialectDefinitionValidationTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/DialectDefinitionValidationTest.scala
@@ -92,4 +92,12 @@ class DialectDefinitionValidationTest extends AsyncFunSuite with Matchers with D
              Some("/unknown-map-key-property/dialect.report"),
              jsonldReport = false)
   }
+
+  test("Empty type discriminator value") {
+    validate(
+        "/empty-discriminator-value/dialect-with-empty-type-discriminator-value.yaml",
+        Some("/empty-discriminator-value/dialect-with-empty-type-discriminator-value.report"),
+        jsonldReport = false
+    )
+  }
 }

--- a/amf-aml/shared/src/test/scala/amf/dialects/DialectsParsingTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/dialects/DialectsParsingTest.scala
@@ -16,7 +16,11 @@ trait DialectsParsingTest extends DialectTests {
   }
 
   multiGoldenTest("parse 1b test", "example1b.%s") { config =>
-    cycle("example1b.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example1b.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 2 test", "example2.%s") { config =>
@@ -52,55 +56,107 @@ trait DialectsParsingTest extends DialectTests {
   }
 
   multiGoldenTest("parse 10 test", "example10.%s") { config =>
-    cycle("example10.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example10.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 11 test", "example11.%s") { config =>
-    cycle("example11.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example11.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 12 test", "example12.%s") { config =>
-    cycle("example12.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example12.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 13 test", "example13.%s") { config =>
-    cycle("example13.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example13.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 14 test", "example14.%s") { config =>
-    cycle("example14.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example14.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 15 test", "example15.%s") { config =>
-    cycle("example15.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example15.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 16 test", "example16.%s") { config =>
-    cycle("example16.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example16.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 17 test", "example17.%s") { config =>
-    cycle("example17.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example17.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 18 test", "example18.%s") { config =>
-    cycle("example18.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example18.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 19 test", "example19.%s") { config =>
-    cycle("example19.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example19.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 20 test", "example20.%s") { config =>
-    cycle("example20.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example20.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 21 test", "example21.%s") { config =>
-    cycle("example21.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example21.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 22 test", "example22.%s") { config =>
-    cycle("example22.yaml", config.golden, VocabularyYamlHint, target = Amf, renderOptions = Some(config.renderOptions))
+    cycle("example22.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 
   multiGoldenTest("parse 23a test", "example23a.%s") { config =>
@@ -302,5 +358,21 @@ trait DialectsParsingTest extends DialectTests {
           target = Amf,
           renderOptions = Some(config.renderOptions),
           directory = s"$basePath/dialect-library")
+  }
+
+  multiGoldenTest("Parse empty but present type discriminator field", "empty-type-discriminator-field.%s") { config =>
+    cycle("empty-type-discriminator-field.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
+  }
+
+  multiGoldenTest("Parse empty value in type discriminator", "empty-type-discriminator-value.%s") { config =>
+    cycle("empty-type-discriminator-value.yaml",
+          config.golden,
+          VocabularyYamlHint,
+          target = Amf,
+          renderOptions = Some(config.renderOptions))
   }
 }


### PR DESCRIPTION
Index out of bound exception when parsing a dialect that has no value for a type discriminator such as:
 
```
#%Dialect 1.0
dialect: Test Unions
version: 1.0
nodeMappings:
  A:
    classTerm: vocab.something
    mapping:
       ...
  B:
    classTerm: vocab.something
    mapping:
       ...
  RootNode:
    union:
      - A
      - B
    typeDiscriminatorName: kind
    typeDiscriminator:
      TypeA: 
```
Not sure if the solution applied is best, maybe we should just filter empty values?