### PR TITLE
APIMF-3048: add javadoc and remove private[amf]

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/client/environment/AMLClient.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/environment/AMLClient.scala
@@ -7,8 +7,7 @@ import amf.plugins.document.vocabularies.model.document.{Dialect, DialectInstanc
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * AML Client object
-  * @param configuration {@link amf.client.environment.AMLConfiguration}
+  * The AML Client provides common AML use cases and handles typed results
   */
 class AMLClient private[amf] (protected override val configuration: AMLConfiguration)
     extends AMFGraphClient(configuration) {

--- a/amf-aml/shared/src/main/scala/amf/client/environment/AMLClient.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/environment/AMLClient.scala
@@ -6,25 +6,44 @@ import amf.plugins.document.vocabularies.model.document.{Dialect, DialectInstanc
 
 import scala.concurrent.{ExecutionContext, Future}
 
-// TODO: ARM remove private[amf]
-private[amf] class AMLClient(protected override val configuration: AMLConfiguration)
+/**
+  * AML Client object
+  * @param configuration {@link amf.client.environment.AMLConfiguration}
+  */
+class AMLClient private[amf] (protected override val configuration: AMLConfiguration)
     extends AMFGraphClient(configuration) {
 
   override implicit val exec: ExecutionContext = configuration.resolvers.executionContext.executionContext
 
   override def getConfiguration: AMLConfiguration = configuration
+
+  /**
+    * parse a {@link amf.plugins.document.vocabularies.model.document.Dialect}
+    * @param url of the resource to parse
+    * @return a Future {@link amf.client.environment.AMLDialectResult}
+    */
   def parseDialect(url: String): Future[AMLDialectResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Dialect, r) => new AMLDialectResult(d, r)
     case other =>
       throw InvalidBaseUnitTypeException.forMeta(other.bu.meta, DialectModel)
   }
 
+  /**
+    * parse a {@link amf.plugins.document.vocabularies.model.document.DialectInstance}
+    * @param url of the resource to parse
+    * @return a Future {@link amf.client.environment.AMLDialectInstanceResult}
+    */
   def parseDialectInstance(url: String): Future[AMLDialectInstanceResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: DialectInstance, r) => new AMLDialectInstanceResult(d, r)
     case other =>
       throw InvalidBaseUnitTypeException.forMeta(other.bu.meta, DialectInstanceModel)
   }
 
+  /**
+    * parse a {@link amf.plugins.document.vocabularies.model.document.Vocabulary}
+    * @param url of the resource to parse
+    * @return a Future {@link amf.client.environment.AMLVocabularyResult}
+    */
   def parseVocabulary(url: String): Future[AMLVocabularyResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Vocabulary, r) => new AMLVocabularyResult(d, r)
     case other =>

--- a/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
@@ -24,12 +24,21 @@ import org.mulesoft.common.collections.FilterType
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-private[amf] class AMLConfiguration(override private[amf] val resolvers: AMFResolvers,
-                                    override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
-                                    override private[amf] val registry: AMFRegistry,
-                                    override private[amf] val logger: AMFLogger,
-                                    override private[amf] val listeners: Set[AMFEventListener],
-                                    override private[amf] val options: AMFOptions)
+/**
+  * The configuration object required for using AML
+  * @param resolvers {@link amf.client.remod.amfcore.config.AMFResolvers}
+  * @param errorHandlerProvider {@link amf.client.remod.ErrorHandlerProvider}
+  * @param registry {@link amf.client.remod.amfcore.registry.AMFRegistry}
+  * @param logger {@link amf.client.remod.amfcore.config.AMFLogger}
+  * @param listeners a Set of {@link amf.client.remod.amfcore.config.AMFEventListener}
+  * @param options {@link amf.client.remod.amfcore.config.AMFOptions}
+  */
+class AMLConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
+                                     override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
+                                     override private[amf] val registry: AMFRegistry,
+                                     override private[amf] val logger: AMFLogger,
+                                     override private[amf] val listeners: Set[AMFEventListener],
+                                     override private[amf] val options: AMFOptions)
     extends AMFGraphConfiguration(resolvers, errorHandlerProvider, registry, logger, listeners, options) {
 
   override protected def copy(resolvers: AMFResolvers,
@@ -109,7 +118,7 @@ private[amf] class AMLConfiguration(override private[amf] val resolvers: AMFReso
   def forInstance(d: DialectInstanceUnit) = throw new UnsupportedOperationException()
 }
 
-private[amf] object AMLConfiguration extends PlatformSecrets {
+object AMLConfiguration extends PlatformSecrets {
 
   /**
     * Predefined env to deal with AML documents based on


### PR DESCRIPTION
- Add javadoc to most remodularization classes, methods and objects
- Remove the private[amf] modifier on those classes/methods/objects