### PR TITLE
APIMF-2896: add scaladoc to remod/exported files

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/client/environment/AMLClient.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/environment/AMLClient.scala
@@ -6,9 +6,7 @@ import amf.plugins.document.vocabularies.model.document.{Dialect, DialectInstanc
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/**
-  * The AML Client provides common AML use cases and handles typed results
-  */
+/** Contains common AML operations. Handles typed results. */
 class AMLClient private[amf] (protected override val configuration: AMLConfiguration)
     extends AMFGraphClient(configuration) {
 
@@ -17,9 +15,9 @@ class AMLClient private[amf] (protected override val configuration: AMLConfigura
   override def getConfiguration: AMLConfiguration = configuration
 
   /**
-    * parse a {@link amf.plugins.document.vocabularies.model.document.Dialect}
+    * parse a [[Dialect]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.environment.AMLDialectResult}
+    * @return a Future [[AMLDialectResult]]
     */
   def parseDialect(url: String): Future[AMLDialectResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Dialect, r) => new AMLDialectResult(d, r)
@@ -28,9 +26,9 @@ class AMLClient private[amf] (protected override val configuration: AMLConfigura
   }
 
   /**
-    * parse a {@link amf.plugins.document.vocabularies.model.document.DialectInstance}
+    * parse a [[DialectInstance]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.environment.AMLDialectInstanceResult}
+    * @return a Future [[AMLDialectInstanceResult]]
     */
   def parseDialectInstance(url: String): Future[AMLDialectInstanceResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: DialectInstance, r) => new AMLDialectInstanceResult(d, r)
@@ -39,9 +37,9 @@ class AMLClient private[amf] (protected override val configuration: AMLConfigura
   }
 
   /**
-    * parse a {@link amf.plugins.document.vocabularies.model.document.Vocabulary}
+    * parse a [[Vocabulary]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.environment.AMLVocabularyResult}
+    * @return a Future [[AMLVocabularyResult]]
     */
   def parseVocabulary(url: String): Future[AMLVocabularyResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Vocabulary, r) => new AMLVocabularyResult(d, r)

--- a/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
@@ -35,12 +35,12 @@ import scala.concurrent.Future
 /**
   * The configuration object required for using AML
   *
-  * @param resolvers {@link amf.client.remod.amfcore.config.AMFResolvers}
-  * @param errorHandlerProvider {@link amf.client.remod.ErrorHandlerProvider}
-  * @param registry {@link amf.client.remod.amfcore.registry.AMFRegistry}
-  * @param logger {@link amf.client.exported.config.AMFLogger}
-  * @param listeners a Set of {@link amf.client.exported.config.AMFEventListener}
-  * @param options {@link amf.client.remod.amfcore.config.AMFOptions}
+  * @param resolvers [[AMFResolvers]]
+  * @param errorHandlerProvider [[ErrorHandlerProvider]]
+  * @param registry [[AMFRegistry]]
+  * @param logger [[AMFLogger]]
+  * @param listeners a Set of [[AMFEventListener]]
+  * @param options [[AMFOptions]]
   */
 class AMLConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
                                      override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
@@ -104,11 +104,6 @@ class AMLConfiguration private[amf] (override private[amf] val resolvers: AMFRes
 
   def merge(other: AMLConfiguration): AMLConfiguration = super._merge(other)
 
-  /**
-    *
-    * @param path
-    * @return
-    */
   def withDialect(path: String): Future[AMLConfiguration] = {
     createClient().parse(path).map {
       case AMFResult(d: Dialect, _) => withDialect(d)

--- a/amf-aml/shared/src/main/scala/amf/client/exported/AMLClient.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/exported/AMLClient.scala
@@ -6,6 +6,7 @@ import amf.client.convert.VocabulariesClientConverter._
 
 import scala.concurrent.ExecutionContext
 
+/** Contains common AML operations. Handles typed results. */
 @JSExportAll
 class AMLClient private[amf] (private val _internal: InternalAMLClient) extends AMFGraphClient(_internal) {
 
@@ -19,24 +20,24 @@ class AMLClient private[amf] (private val _internal: InternalAMLClient) extends 
   override def getConfiguration: AMLConfiguration = _internal.getConfiguration
 
   /**
-    * parse a {@link amf.plugins.document.vocabularies.model.document.Dialect}
+    * parse a [[amf.plugins.document.vocabularies.model.document.Dialect]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.environment.AMLDialectResult}
+    * @return a Future [[AMLDialectResult]]
     */
   def parseDialect(url: String): ClientFuture[AMLDialectResult] = _internal.parseDialect(url).asClient
 
   /**
-    * parse a {@link amf.plugins.document.vocabularies.model.document.DialectInstance}
+    * parse a [[amf.plugins.document.vocabularies.model.document.DialectInstance]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.environment.AMLDialectInstanceResult}
+    * @return a Future [[AMLDialectInstanceResult]]
     */
   def parseDialectInstance(url: String): ClientFuture[AMLDialectInstanceResult] =
     _internal.parseDialectInstance(url).asClient
 
   /**
-    * parse a {@link amf.plugins.document.vocabularies.model.document.Vocabulary}
+    * parse a [[amf.plugins.document.vocabularies.model.document.Vocabulary]]
     * @param url of the resource to parse
-    * @return a Future {@link amf.client.environment.AMLVocabularyResult}
+    * @return a Future [[AMLVocabularyResult]]
     */
   def parseVocabulary(url: String): ClientFuture[AMLVocabularyResult] = _internal.parseVocabulary(url).asClient
 }

--- a/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
+++ b/amf-aml/shared/src/main/scala/amf/plugins/document/vocabularies/DialectsRegistry.scala
@@ -39,7 +39,8 @@ class DialectsRegistry extends AMFDomainEntityResolver with PlatformSecrets with
   // Private methods
   private[amf] def env(): AMFGraphConfiguration = AMFPluginsRegistry.staticConfiguration
 
-  private[amf] def setEnv(env: AMFGraphConfiguration): Unit = AMFPluginsRegistry.staticConfiguration = env
+  private[amf] def setEnv(configuration: AMFGraphConfiguration): Unit =
+    AMFPluginsRegistry.staticConfiguration = configuration
 
   private val pipelineRunner = TransformationPipelineRunner(DefaultErrorHandler())
   private[amf] def resolveDialect(dialect: Dialect) = {


### PR DESCRIPTION
- add missing scaladoc
- remove full path from already-imported classes to simplify scaladoc
- refactor `env` parameter name to `configuration`