### PR TITLE
APIMF-3098: add support for partial parsing of the flatten graph

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/client/environment/AMLConfiguration.scala
@@ -14,6 +14,7 @@ import amf.client.remod.rendering.{
 import amf.client.remod.{AMFGraphConfiguration, AMFParser, AMFResult, ErrorHandlerProvider}
 import amf.core.errorhandling.{AMFErrorHandler, UnhandledErrorHandler}
 import amf.core.metamodel.ModelDefaultBuilder
+import amf.core.model.domain.AnnotationGraphLoader
 import amf.core.resolution.pipelines.{TransformationPipeline, TransformationPipelineRunner}
 import amf.core.unsafe.PlatformSecrets
 import amf.core.validation.core.ValidationProfile
@@ -113,6 +114,9 @@ class AMLConfiguration private[amf] (override private[amf] val resolvers: AMFRes
 
   override def withEntities(entities: Map[String, ModelDefaultBuilder]): AMLConfiguration =
     super._withEntities(entities)
+
+  override def withAnnotations(annotations: Map[String, AnnotationGraphLoader]): AMLConfiguration =
+    super._withAnnotations(annotations)
 
   def merge(other: AMLConfiguration): AMLConfiguration = super._merge(other)
 


### PR DESCRIPTION
Depends on:
https://github.com/aml-org/amf-core/pull/260