### PR TITLE
APIMF 3202

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/aml/client/platform/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/platform/AMLConfiguration.scala
@@ -3,7 +3,7 @@ package amf.aml.client.platform
 import amf.aml.client.platform.model.document.Dialect
 import amf.aml.client.scala.{AMLConfiguration => InternalAMLConfiguration}
 import amf.aml.internal.convert.VocabulariesClientConverter._
-import amf.core.client.platform.config.{AMFEventListener, AMFLogger, ParsingOptions, RenderOptions}
+import amf.core.client.platform.config.{AMFEventListener, ParsingOptions, RenderOptions}
 import amf.core.client.platform.errorhandling.ErrorHandlerProvider
 import amf.core.client.platform.reference.UnitCache
 import amf.core.client.platform.resource.ResourceLoader
@@ -39,14 +39,12 @@ class AMLConfiguration private[amf] (private[amf] override val _internal: scala.
     _internal.withResourceLoaders(rl.asInternal.toList)
 
   override def withUnitCache(cache: UnitCache): AMLConfiguration =
-    _internal.withUnitCache(ReferenceResolverMatcher.asInternal(cache))
+    _internal.withUnitCache(UnitCacheMatcher.asInternal(cache))
 
   override def withTransformationPipeline(pipeline: TransformationPipeline): AMLConfiguration =
     _internal.withTransformationPipeline(pipeline)
 
   override def withEventListener(listener: AMFEventListener): AMLConfiguration = _internal.withEventListener(listener)
-
-  override def withLogger(logger: AMFLogger): AMLConfiguration = _internal.withLogger(logger)
 
   override def withDialect(dialect: Dialect): AMLConfiguration = _internal.withDialect(dialect)
 

--- a/amf-aml/shared/src/main/scala/amf/aml/client/platform/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/platform/AMLConfiguration.scala
@@ -13,7 +13,10 @@ import amf.core.internal.convert.TransformationPipelineConverter._
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 import amf.aml.client.scala
+import amf.core.client.platform.AMFGraphConfiguration
 import amf.core.client.platform.execution.BaseExecutionEnvironment
+import amf.core.client.platform.validation.payload.AMFShapePayloadValidationPlugin
+import amf.core.internal.convert.PayloadValidationPluginConverter.PayloadValidationPluginMatcher
 
 @JSExportAll
 class AMLConfiguration private[amf] (private[amf] override val _internal: scala.AMLConfiguration)
@@ -60,6 +63,9 @@ class AMLConfiguration private[amf] (private[amf] override val _internal: scala.
   def withDialect(path: String): ClientFuture[AMLConfiguration] = _internal.withDialect(path).asClient
 
   def forInstance(url: String): ClientFuture[AMLConfiguration] = _internal.forInstance(url).asClient
+
+  override def withShapePayloadPlugin(plugin: AMFShapePayloadValidationPlugin): AMLConfiguration =
+    _internal.withPlugin(PayloadValidationPluginMatcher.asInternal(plugin))
 }
 
 @JSExportAll

--- a/amf-aml/shared/src/main/scala/amf/aml/client/platform/BaseAMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/platform/BaseAMLConfiguration.scala
@@ -4,7 +4,7 @@ import amf.aml.client.platform.model.document.Dialect
 import amf.aml.internal.convert.VocabulariesClientConverter._
 import amf.aml.client.scala.{AMLConfiguration => InternalAMLConfiguration}
 import amf.core.client.platform.AMFGraphConfiguration
-import amf.core.client.platform.config.{AMFEventListener, AMFLogger, ParsingOptions, RenderOptions}
+import amf.core.client.platform.config.{AMFEventListener, ParsingOptions, RenderOptions}
 import amf.core.client.platform.errorhandling.ErrorHandlerProvider
 import amf.core.client.platform.reference.UnitCache
 import amf.core.client.platform.resource.ResourceLoader
@@ -36,16 +36,13 @@ class BaseAMLConfiguration private[amf] (private[amf] override val _internal: In
     new BaseAMLConfiguration(_internal.withResourceLoaders(rl.asInternal.toList))
 
   override def withUnitCache(cache: UnitCache): BaseAMLConfiguration =
-    new BaseAMLConfiguration(_internal.withUnitCache(ReferenceResolverMatcher.asInternal(cache)))
+    new BaseAMLConfiguration(_internal.withUnitCache(UnitCacheMatcher.asInternal(cache)))
 
   override def withTransformationPipeline(pipeline: TransformationPipeline): BaseAMLConfiguration =
     new BaseAMLConfiguration(_internal.withTransformationPipeline(pipeline))
 
   override def withEventListener(listener: AMFEventListener): BaseAMLConfiguration =
     new BaseAMLConfiguration(_internal.withEventListener(listener))
-
-  override def withLogger(logger: AMFLogger): BaseAMLConfiguration =
-    new BaseAMLConfiguration(_internal.withLogger(logger))
 
   def withDialect(dialect: Dialect): BaseAMLConfiguration =
     new BaseAMLConfiguration(_internal.withDialect(dialect))

--- a/amf-aml/shared/src/main/scala/amf/aml/client/scala/AMLBaseUnitClient.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/scala/AMLBaseUnitClient.scala
@@ -26,7 +26,7 @@ class AMLBaseUnitClient private[amf](protected override val configuration: AMLCo
   def parseDialect(url: String): Future[AMLDialectResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Dialect, r) => new AMLDialectResult(d, r)
     case other =>
-      throw InvalidBaseUnitTypeException.forMeta(other.bu.meta, DialectModel)
+      throw InvalidBaseUnitTypeException.forMeta(other.baseUnit.meta, DialectModel)
   }
 
   /**
@@ -37,7 +37,7 @@ class AMLBaseUnitClient private[amf](protected override val configuration: AMLCo
   def parseDialectInstance(url: String): Future[AMLDialectInstanceResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: DialectInstance, r) => new AMLDialectInstanceResult(d, r)
     case other =>
-      throw InvalidBaseUnitTypeException.forMeta(other.bu.meta, DialectInstanceModel)
+      throw InvalidBaseUnitTypeException.forMeta(other.baseUnit.meta, DialectInstanceModel)
   }
 
   /**
@@ -49,7 +49,7 @@ class AMLBaseUnitClient private[amf](protected override val configuration: AMLCo
   def parseValidationProfile(url: String): Future[ValidationProfile] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: DialectInstance, _) => parseValidationProfile(d)
     case other =>
-      throw InvalidBaseUnitTypeException.forMeta(other.bu.meta, DialectInstanceModel)
+      throw InvalidBaseUnitTypeException.forMeta(other.baseUnit.meta, DialectInstanceModel)
   }
 
   def parseValidationProfile(dialect: DialectInstance): ValidationProfile = {
@@ -67,6 +67,6 @@ class AMLBaseUnitClient private[amf](protected override val configuration: AMLCo
   def parseVocabulary(url: String): Future[AMLVocabularyResult] = AMFParser.parse(url, configuration).map {
     case AMFResult(d: Vocabulary, r) => new AMLVocabularyResult(d, r)
     case other =>
-      throw InvalidBaseUnitTypeException.forMeta(other.bu.meta, VocabularyModel)
+      throw InvalidBaseUnitTypeException.forMeta(other.baseUnit.meta, VocabularyModel)
   }
 }

--- a/amf-aml/shared/src/main/scala/amf/aml/client/scala/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/scala/AMLConfiguration.scala
@@ -19,7 +19,6 @@ import amf.aml.internal.render.plugin.{
 import amf.aml.internal.transform.pipelines.{DefaultAMLTransformationPipeline, DialectTransformationPipeline}
 import amf.aml.internal.utils.{DialectRegister, VocabulariesRegister}
 import amf.aml.internal.validate.{AMFDialectValidations, AMLValidationPlugin}
-import amf.core.client.platform.config.{AMFLogger, MutedLogger}
 import amf.core.client.scala.config._
 import amf.core.client.scala.errorhandling.{
   AMFErrorHandler,
@@ -50,17 +49,15 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param resolvers [[AMFResolvers]]
   * @param errorHandlerProvider [[ErrorHandlerProvider]]
   * @param registry [[AMFRegistry]]
-  * @param logger [[AMFLogger]]
   * @param listeners a Set of [[AMFEventListener]]
   * @param options [[AMFOptions]]
   */
 class AMLConfiguration private[amf] (override private[amf] val resolvers: AMFResolvers,
                                      override private[amf] val errorHandlerProvider: ErrorHandlerProvider,
                                      override private[amf] val registry: AMFRegistry,
-                                     override private[amf] val logger: AMFLogger,
                                      override private[amf] val listeners: Set[AMFEventListener],
                                      override private[amf] val options: AMFOptions)
-    extends AMFGraphConfiguration(resolvers, errorHandlerProvider, registry, logger, listeners, options) {
+    extends AMFGraphConfiguration(resolvers, errorHandlerProvider, registry, listeners, options) {
 
   private implicit val ec: ExecutionContext = this.getExecutionContext
 
@@ -69,10 +66,9 @@ class AMLConfiguration private[amf] (override private[amf] val resolvers: AMFRes
   override protected def copy(resolvers: AMFResolvers,
                               errorHandlerProvider: ErrorHandlerProvider,
                               registry: AMFRegistry,
-                              logger: AMFLogger,
                               listeners: Set[AMFEventListener],
                               options: AMFOptions): AMLConfiguration =
-    new AMLConfiguration(resolvers, errorHandlerProvider, registry, logger, listeners, options)
+    new AMLConfiguration(resolvers, errorHandlerProvider, registry, listeners, options)
 
   override def baseUnitClient(): AMLBaseUnitClient = new AMLBaseUnitClient(this)
   def elementClient(): AMLElementClient            = new AMLElementClient(this)
@@ -117,8 +113,6 @@ class AMLConfiguration private[amf] (override private[amf] val resolvers: AMFRes
     super._withErrorHandlerProvider(provider)
 
   override def withEventListener(listener: AMFEventListener): AMLConfiguration = super._withEventListener(listener)
-
-  override def withLogger(logger: AMFLogger): AMLConfiguration = super._withLogger(logger)
 
   override def withEntities(entities: Map[String, ModelDefaultBuilder]): AMLConfiguration =
     super._withEntities(entities)
@@ -187,7 +181,6 @@ object AMLConfiguration extends PlatformSecrets {
         predefinedGraphConfiguration.registry
           .withEntities(AMLEntities.entities)
           .withAnnotations(AMLSerializableAnnotations.annotations),
-        predefinedGraphConfiguration.logger,
         predefinedGraphConfiguration.listeners,
         predefinedGraphConfiguration.options
     ).withPlugins(predefinedPlugins)
@@ -203,7 +196,6 @@ object AMLConfiguration extends PlatformSecrets {
         AMFResolvers.predefined(),
         DefaultErrorHandlerProvider,
         AMFRegistry.empty,
-        MutedLogger,
         Set.empty,
         AMFOptions.default()
     )

--- a/amf-aml/shared/src/test/scala/amf/testing/resolution/DialectInstanceResolutionCycleTests.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/resolution/DialectInstanceResolutionCycleTests.scala
@@ -7,5 +7,5 @@ import amf.testing.common.utils.DialectTests
 
 abstract class DialectInstanceResolutionCycleTests extends DialectTests {
   override def transform(unit: BaseUnit, amlConfig: AMLConfiguration): BaseUnit =
-    amlConfig.baseUnitClient().transform(unit, DefaultAMLTransformationPipeline.name).bu
+    amlConfig.baseUnitClient().transform(unit, DefaultAMLTransformationPipeline.name).baseUnit
 }

--- a/amf-aml/shared/src/test/scala/amf/testing/resolution/DialectProductionResolutionTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/resolution/DialectProductionResolutionTest.scala
@@ -14,7 +14,7 @@ class DialectProductionResolutionTest extends FunSuiteCycleTests with DialectIns
   override implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
 
   override def transform(unit: BaseUnit, config: CycleConfig, amlConfig: AMLConfiguration): BaseUnit =
-    amlConfig.baseUnitClient().transform(unit, DefaultAMLTransformationPipeline.name).bu
+    amlConfig.baseUnitClient().transform(unit, DefaultAMLTransformationPipeline.name).baseUnit
 
   val basePath = "amf-aml/shared/src/test/resources/vocabularies2/production/"
 

--- a/amf-aml/shared/src/test/scala/amf/testing/resolution/DialectResolutionCycleTests.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/resolution/DialectResolutionCycleTests.scala
@@ -7,5 +7,5 @@ import amf.testing.common.cycling.FunSuiteCycleTests
 
 abstract class DialectResolutionCycleTests extends FunSuiteCycleTests {
   override def transform(unit: BaseUnit, config: CycleConfig, amlConfig: AMLConfiguration): BaseUnit =
-    amlConfig.baseUnitClient().transform(unit, DefaultAMLTransformationPipeline.name).bu
+    amlConfig.baseUnitClient().transform(unit, DefaultAMLTransformationPipeline.name).baseUnit
 }


### PR DESCRIPTION
- APIMF-3092/0: Deleted AMF Logger
- APIMF-3092/1: Renamed bu for baseUnit
- APIMF-3092/2: added method to AMLConfig to be coherent with AMFGraphConfig
- Fixed rebase changes

Related to: https://github.com/aml-org/amf-core/pull/291
