### PR TITLE
APIMF-3305: dialect instance plugin ids are now formed with the dialect name and version of the instance

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/aml/internal/namespace/AMLDialectNamespaceAliasesPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/namespace/AMLDialectNamespaceAliasesPlugin.scala
@@ -19,7 +19,7 @@ case class AMLDialectNamespaceAliasesPlugin private (dialect: Dialect, aliases: 
 
   override def aliases(_unit: BaseUnit): NamespaceAliases = aliases
 
-  override val id: String = s"${dialect.id}/dialect-namespace-generation-plugin"
+  override val id: String = s"${dialect.nameAndVersion()}/dialect-namespace-generation-plugin"
 
   override def priority: PluginPriority = NormalPriority
 }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/AMLDialectInstanceParsingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/AMLDialectInstanceParsingPlugin.scala
@@ -33,7 +33,7 @@ class AMLDialectInstanceParsingPlugin(val dialect: Dialect)
     extends AMFParsePlugin
     with AMLDialectInstancePlugin[Root] {
 
-  override val id: String = s"${dialect.id}/dialect-instances-parsing-plugin"
+  override val id: String = s"${dialect.nameAndVersion()}/dialect-instances-parsing-plugin"
 
   override def priority: PluginPriority = NormalPriority
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/AmlEmittersHelper.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/AmlEmittersHelper.scala
@@ -34,10 +34,8 @@ object DefaultNodeMappableFinder {
     }
     new DefaultNodeMappableFinder(knownDialects)
   }
-  def apply(ctx: AMLConfiguration) = {
-    val knownDialects = ctx.registry.plugins.parsePlugins.collect {
-      case plugin: AMLDialectInstanceParsingPlugin => plugin.dialect
-    }
+  def apply(config: AMLConfiguration) = {
+    val knownDialects = config.configurationState().getDialects()
     new DefaultNodeMappableFinder(knownDialects)
   }
   def empty() = new DefaultNodeMappableFinder(Seq.empty)

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectInstanceRenderingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectInstanceRenderingPlugin.scala
@@ -16,7 +16,7 @@ import amf.core.internal.remote.Mimes._
 class AMLDialectInstanceRenderingPlugin(val dialect: Dialect)
     extends AMFRenderPlugin
     with AMLDialectInstancePlugin[RenderInfo] {
-  override val id: String = s"${dialect.id}/dialect-instances-rendering-plugin"
+  override val id: String = s"${dialect.nameAndVersion()}/dialect-instances-rendering-plugin"
 
   override def priority: PluginPriority = NormalPriority
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/utils/DialectRegister.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/utils/DialectRegister.scala
@@ -29,11 +29,9 @@ private[amf] case class DialectRegister(d: Dialect) {
   }
 
   def register(amlConfig: AMLConfiguration): AMLConfiguration = {
-    val existingDialects = amlConfig.registry.plugins.parsePlugins.collect {
-      case plugin: AMLDialectInstanceParsingPlugin => plugin.dialect
-    }
-    val finder  = DefaultNodeMappableFinder(existingDialects)
-    val profile = new AMFDialectValidations(dialect)(finder).profile() // TODO ARM if i use resolved dialect this throws null pointer
+    val existingDialects = amlConfig.configurationState().getDialects()
+    val finder           = DefaultNodeMappableFinder(existingDialects)
+    val profile          = new AMFDialectValidations(dialect)(finder).profile() // TODO ARM if i use resolved dialect this throws null pointer
     val newConfig = amlConfig
       .withPlugins(plugins)
       .withValidationProfile(profile)

--- a/amf-aml/shared/src/test/resources/vocabularies2/config/dialect_0.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/config/dialect_0.yaml
@@ -1,0 +1,19 @@
+#%Dialect 1.0
+
+dialect: Movie
+version: 1.0
+
+external:
+  schema: https://schema.org/
+
+documents:
+  root:
+    encodes: MovieNode
+
+nodeMappings:
+  MovieNode:
+    mapping:
+      name:
+        propertyTerm: schema.name
+        mandatory: true
+        range: string

--- a/amf-aml/shared/src/test/resources/vocabularies2/config/dialect_1.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/config/dialect_1.yaml
@@ -1,0 +1,23 @@
+#%Dialect 1.0
+
+dialect: Movie
+version: 1.0
+
+external:
+  schema: https://schema.org/
+
+documents:
+  root:
+    encodes: MovieNode
+
+nodeMappings:
+  MovieNode:
+    mapping:
+      name:
+        propertyTerm: schema.name
+        mandatory: true
+        range: string
+      year:
+        propertyTerm: schema.year
+        range: integer
+        mandatory: true

--- a/amf-aml/shared/src/test/scala/amf/testing/config/AMLConfigurationPluginTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/config/AMLConfigurationPluginTest.scala
@@ -1,0 +1,47 @@
+package amf.testing.config
+
+import amf.aml.client.scala.model.domain.{DialectDomainElement, NodeMapping}
+import amf.aml.client.scala.AMLConfiguration
+import amf.aml.internal.parse.plugin.AMLDialectInstanceParsingPlugin
+import amf.aml.internal.render.plugin.AMLDialectInstanceRenderingPlugin
+import org.scalatest.{Assertion, AsyncFunSuite, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AMLConfigurationPluginTest extends AsyncFunSuite with Matchers {
+
+  override implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+
+  val basePath      = "file://amf-aml/shared/src/test/resources/vocabularies2/config/"
+  val firstDialect  = "dialect_0.yaml"
+  val secondDialect = "dialect_1.yaml"
+
+  test("Loading dialects with same name and version should update plugins") {
+    withLoadedConfig(pathName = "dialect_0.yaml") { config =>
+      withLoadedConfig(config, pathName = "dialect_1.yaml") { finalConfig =>
+        assertDialectAndPluginAmount(expectedAmount = 1, finalConfig)
+
+        val dialect = finalConfig.configurationState().getDialects().head
+        dialect.declares.head.asInstanceOf[NodeMapping].propertiesMapping() should have length 2
+      }
+    }
+  }
+
+  private def assertDialectAndPluginAmount(expectedAmount: Int, config: AMLConfiguration) = {
+    val dialects = config.configurationState().getDialects()
+    dialects.size shouldBe 1
+    config.registry.plugins.parsePlugins
+      .filter(_.isInstanceOf[AMLDialectInstanceParsingPlugin]) should have length 1
+    config.registry.plugins.renderPlugins
+      .filter(_.isInstanceOf[AMLDialectInstanceRenderingPlugin]) should have length 1
+  }
+
+  private def withLoadedConfig(config: AMLConfiguration = AMLConfiguration.predefined(), pathName: String)(
+      block: AMLConfiguration => Future[Assertion]) = {
+    val futureResult = config.baseUnitClient().parseDialect(basePath + pathName)
+    futureResult.flatMap { result =>
+      result.conforms shouldBe true
+      block(config.withDialect(result.dialect))
+    }
+  }
+}


### PR DESCRIPTION
Depends on: https://github.com/aml-org/amf-core/pull/315