### PR TITLE
APIMF 3437

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/aml/client/scala/AMLConfiguration.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/scala/AMLConfiguration.scala
@@ -242,10 +242,6 @@ object AMLConfiguration extends PlatformSecrets {
     ).withPlugins(predefinedPlugins)
       .withTransformationPipeline(DefaultAMLTransformationPipeline())
   }
-  //TODO ARM remove
-  private[amf] def forEH(eh: AMFErrorHandler) = {
-    predefined().withErrorHandlerProvider(() => eh)
-  }
 
   def empty(): AMLConfiguration = {
     new AMLConfiguration(

--- a/amf-aml/shared/src/main/scala/amf/aml/client/scala/model/domain/DialectDomainElement.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/scala/model/domain/DialectDomainElement.scala
@@ -174,7 +174,7 @@ case class DialectDomainElement(override val fields: Fields, annotations: Annota
     this
   }
 
-  // TODO: WHY???
+  // TODO: This should receive annotations instead of an entry. Unrelated concepts in the same method (how annotations are formed and how to store the value and where)
   private[amf] def setProperty(property: PropertyMapping, entry: YMapEntry): DialectDomainElement = {
     set(property.toField, AmfScalar(entry.value, Annotations(entry.value)), Annotations(entry))
     this

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/instances/DialectInstanceParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/instances/DialectInstanceParser.scala
@@ -998,6 +998,7 @@ class DialectInstanceParser(val root: Root)(implicit override val ctx: DialectIn
     }
   }
 
+  // TODO: This should receive annotations instead of an entry. Unrelated concepts in the same method
   protected def setLiteralValue(entry: YMapEntry, property: PropertyMapping, node: DialectDomainElement): Unit = {
     parseLiteralValue(entry.value, property, node) match {
       case Some(b: Boolean)          => node.setProperty(property, b, entry)

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/AMLDialectParsingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/AMLDialectParsingPlugin.scala
@@ -3,6 +3,7 @@ package amf.aml.internal.parse.plugin
 import amf.aml.internal.parse.common.SyntaxExtensionsReferenceHandler
 import amf.aml.internal.parse.dialects.{DialectContext, DialectsParser}
 import amf.aml.internal.parse.headers.{DialectHeader, ExtensionHeader}
+import amf.aml.internal.parse.plugin.error.CannotParseDocumentException
 import amf.core.client.common.{NormalPriority, PluginPriority}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
@@ -31,7 +32,8 @@ class AMLDialectParsingPlugin extends AMFParsePlugin {
         new DialectsParser(document)(new DialectContext(ctx)).parseFragment()
       case Some(ExtensionHeader.DialectHeader) =>
         parseDialect(document, cleanDialectContext(ctx, document))
-      case _ => throw new Exception("Dunno") // TODO: ARM - what to do with this
+      case Some(header) => throw CannotParseDocumentException(s"Header $header is not a valid AML Dialect header")
+      case _            => throw CannotParseDocumentException("Missing header for AML Dialect")
     }
   }
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/AMLVocabularyParsingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/AMLVocabularyParsingPlugin.scala
@@ -2,6 +2,7 @@ package amf.aml.internal.parse.plugin
 
 import amf.aml.internal.parse.common.SyntaxExtensionsReferenceHandler
 import amf.aml.internal.parse.headers.{DialectHeader, ExtensionHeader}
+import amf.aml.internal.parse.plugin.error.CannotParseDocumentException
 import amf.aml.internal.parse.vocabularies.{VocabulariesParser, VocabularyContext}
 import amf.core.client.common.{NormalPriority, PluginPriority}
 import amf.core.client.scala.errorhandling.AMFErrorHandler
@@ -22,7 +23,8 @@ class AMLVocabularyParsingPlugin extends AMFParsePlugin {
     header match {
       case Some(ExtensionHeader.VocabularyHeader) =>
         new VocabulariesParser(document)(new VocabularyContext(ctx)).parseDocument()
-      case _ => throw new Exception("Dunno") // TODO: ARM - what to do with this
+      case Some(header) => throw CannotParseDocumentException(s"Header $header is not a valid AML Vocabulary header")
+      case _            => throw CannotParseDocumentException("Missing header for AML Vocabulary")
     }
   }
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/error/CannotParseDocumentException.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/plugin/error/CannotParseDocumentException.scala
@@ -1,0 +1,3 @@
+package amf.aml.internal.parse.plugin.error
+
+case class CannotParseDocumentException(message: String) extends Exception(s"Cannot parse document: $message")

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectRenderingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectRenderingPlugin.scala
@@ -34,7 +34,7 @@ class AMLDialectRenderingPlugin extends SYAMLBasedRenderPlugin {
   }
 
   private def emitDoc(unit: BaseUnit, renderConfiguration: RenderConfiguration) = {
-    // TODO ARM: Fragment????
+    // TODO: Fragment????
     val dialects = renderConfiguration.renderPlugins.collect {
       case plugin: AMLDialectInstanceRenderingPlugin => plugin.dialect
     }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/utils/DialectRegister.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/utils/DialectRegister.scala
@@ -17,7 +17,6 @@ import amf.core.internal.metamodel.domain.{ModelDoc, ModelVocabularies}
 import amf.core.internal.metamodel.{Field, Type}
 import amf.core.internal.plugins.AMFPlugin
 
-// TODO ARM check this object
 private[amf] case class DialectRegister(d: Dialect, configuration: AMLConfiguration) {
 
   val dialect: Dialect = {
@@ -31,7 +30,7 @@ private[amf] case class DialectRegister(d: Dialect, configuration: AMLConfigurat
   def register(): AMLConfiguration = {
     val existingDialects = configuration.configurationState().getDialects()
     val finder           = DefaultNodeMappableFinder(existingDialects)
-    val profile          = new AMFDialectValidations(dialect)(finder).profile() // TODO ARM if i use resolved dialect this throws null pointer
+    val profile          = new AMFDialectValidations(dialect)(finder).profile()
     val newConfig = configuration
       .withPlugins(plugins)
       .withValidationProfile(profile)
@@ -54,7 +53,7 @@ private[amf] case class DialectRegister(d: Dialect, configuration: AMLConfigurat
   private lazy val domainModels = {
     dialect.declares
       .collect({
-        case n: NodeMapping => n.id -> buildMetamodel(n) // TODO ARM wrong, for compatibilidad
+        case n: NodeMapping => n.id -> buildMetamodel(n)
       })
       .toMap
   }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/validate/AMLValidator.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/validate/AMLValidator.scala
@@ -4,6 +4,7 @@ import amf.aml.client.scala.model.document.{Dialect, DialectInstanceUnit}
 import amf.aml.internal.parse.plugin.AMLDialectInstanceParsingPlugin
 import amf.aml.internal.transform.pipelines.DialectInstanceTransformationPipeline
 import amf.core.client.common.validation.ProfileName
+import amf.core.client.scala.config.SkippedValidationPluginEvent
 import amf.core.client.scala.errorhandling.UnhandledErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
 import amf.core.client.scala.transform.TransformationPipelineRunner
@@ -49,8 +50,14 @@ class AMLValidator() extends ShaclReportAdaptation {
         }
 
       case _ =>
-        // TODO ARM: add logging that stage was skipped
+        notifyValidationSkipped(options)
         Future.successful(ValidationResult(baseUnit, AMFValidationReport.empty(baseUnit.id, profile)))
+    }
+  }
+
+  private def notifyValidationSkipped(options: ValidationOptions) = {
+    options.config.listeners.foreach { listener =>
+      listener.notifyEvent(SkippedValidationPluginEvent("AMLValidator", "BaseUnit isn't a DialectInstance"))
     }
   }
 

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/example15.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/example15.expanded.jsonld
@@ -164,14 +164,37 @@
         ]
       }
     ],
-    "http://a.ml/vocabularies/document#version": [
-      {
-        "@value": "3.1.0"
-      }
-    ],
     "http://a.ml/vocabularies/document#root": [
       {
         "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#processingData": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example15.yaml/BaseUnitProcessingData",
+        "@type": [
+          "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+        ],
+        "http://a.ml/vocabularies/meta#definedBy": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect15a.yaml"
+          }
+        ],
+        "http://a.ml/vocabularies/document#graphDependencies": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect15b.yaml"
+          }
+        ],
+        "http://a.ml/vocabularies/document#transformed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://a.ml/vocabularies/document#sourceSpec": [
+          {
+            "@value": "TestInstance 1.15a"
+          }
+        ]
       }
     ],
     "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/example15.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/example15.flattened.jsonld
@@ -1,6 +1,24 @@
 {
   "@graph": [
     {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example15.yaml/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+      ],
+      "http://a.ml/vocabularies/meta#definedBy": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect15a.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#graphDependencies": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect15b.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#transformed": false,
+      "http://a.ml/vocabularies/document#sourceSpec": "TestInstance 1.15a"
+    },
+    {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example15.yaml#/encodes",
       "@type": [
         "http://test.com/v2#A",
@@ -143,8 +161,10 @@
       "http://a.ml/vocabularies/document#encodes": {
         "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example15.yaml#/encodes"
       },
-      "http://a.ml/vocabularies/document#version": "3.1.0",
       "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example15.yaml/BaseUnitProcessingData"
+      },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example15.yaml#/source-map"

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.expanded.jsonld
@@ -124,14 +124,37 @@
         ]
       }
     ],
-    "http://a.ml/vocabularies/document#version": [
-      {
-        "@value": "3.1.0"
-      }
-    ],
     "http://a.ml/vocabularies/document#root": [
       {
         "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#processingData": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.yaml/BaseUnitProcessingData",
+        "@type": [
+          "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+        ],
+        "http://a.ml/vocabularies/meta#definedBy": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16a.yaml"
+          }
+        ],
+        "http://a.ml/vocabularies/document#graphDependencies": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+          }
+        ],
+        "http://a.ml/vocabularies/document#transformed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://a.ml/vocabularies/document#sourceSpec": [
+          {
+            "@value": "TestInstance 1.16a"
+          }
+        ]
       }
     ],
     "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -274,14 +297,32 @@
             ]
           }
         ],
-        "http://a.ml/vocabularies/document#version": [
-          {
-            "@value": "3.1.0"
-          }
-        ],
         "http://a.ml/vocabularies/document#root": [
           {
             "@value": false
+          }
+        ],
+        "http://a.ml/vocabularies/document#processingData": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml/BaseUnitProcessingData",
+            "@type": [
+              "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+            ],
+            "http://a.ml/vocabularies/meta#definedBy": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document#transformed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://a.ml/vocabularies/document#sourceSpec": [
+              {
+                "@value": "TestInstance 1.16b"
+              }
+            ]
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.flattened.jsonld
@@ -1,6 +1,24 @@
 {
   "@graph": [
     {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.yaml/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+      ],
+      "http://a.ml/vocabularies/meta#definedBy": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16a.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#graphDependencies": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#transformed": false,
+      "http://a.ml/vocabularies/document#sourceSpec": "TestInstance 1.16a"
+    },
+    {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.yaml#/encodes",
       "@type": [
         "http://test.com/v2#A",
@@ -114,8 +132,10 @@
       "http://a.ml/vocabularies/document#encodes": {
         "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.yaml#/encodes"
       },
-      "http://a.ml/vocabularies/document#version": "3.1.0",
       "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.yaml/BaseUnitProcessingData"
+      },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16a.yaml#/source-map"
@@ -138,8 +158,10 @@
       "http://a.ml/vocabularies/document#encodes": {
         "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/encodes"
       },
-      "http://a.ml/vocabularies/document#version": "3.1.0",
       "http://a.ml/vocabularies/document#root": false,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml/BaseUnitProcessingData"
+      },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/source-map"
@@ -173,6 +195,19 @@
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/encodes/source-map"
         }
       ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+      ],
+      "http://a.ml/vocabularies/meta#definedBy": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#transformed": false,
+      "http://a.ml/vocabularies/document#sourceSpec": "TestInstance 1.16b"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/source-map",

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.expanded.jsonld
@@ -139,14 +139,37 @@
         ]
       }
     ],
-    "http://a.ml/vocabularies/document#version": [
-      {
-        "@value": "3.1.0"
-      }
-    ],
     "http://a.ml/vocabularies/document#root": [
       {
         "@value": true
+      }
+    ],
+    "http://a.ml/vocabularies/document#processingData": [
+      {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.yaml/BaseUnitProcessingData",
+        "@type": [
+          "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+        ],
+        "http://a.ml/vocabularies/meta#definedBy": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16a.yaml"
+          }
+        ],
+        "http://a.ml/vocabularies/document#graphDependencies": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+          }
+        ],
+        "http://a.ml/vocabularies/document#transformed": [
+          {
+            "@value": false
+          }
+        ],
+        "http://a.ml/vocabularies/document#sourceSpec": [
+          {
+            "@value": "TestInstance 1.16a"
+          }
+        ]
       }
     ],
     "http://a.ml/vocabularies/document-source-maps#sources": [
@@ -289,14 +312,32 @@
             ]
           }
         ],
-        "http://a.ml/vocabularies/document#version": [
-          {
-            "@value": "3.1.0"
-          }
-        ],
         "http://a.ml/vocabularies/document#root": [
           {
             "@value": false
+          }
+        ],
+        "http://a.ml/vocabularies/document#processingData": [
+          {
+            "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml/BaseUnitProcessingData",
+            "@type": [
+              "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+            ],
+            "http://a.ml/vocabularies/meta#definedBy": [
+              {
+                "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+              }
+            ],
+            "http://a.ml/vocabularies/document#transformed": [
+              {
+                "@value": false
+              }
+            ],
+            "http://a.ml/vocabularies/document#sourceSpec": [
+              {
+                "@value": "TestInstance 1.16b"
+              }
+            ]
           }
         ],
         "http://a.ml/vocabularies/document-source-maps#sources": [

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.flattened.jsonld
@@ -1,6 +1,24 @@
 {
   "@graph": [
     {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.yaml/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+      ],
+      "http://a.ml/vocabularies/meta#definedBy": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16a.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#graphDependencies": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#transformed": false,
+      "http://a.ml/vocabularies/document#sourceSpec": "TestInstance 1.16a"
+    },
+    {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.yaml#/encodes",
       "@type": [
         "http://test.com/v2#A",
@@ -124,8 +142,10 @@
       "http://a.ml/vocabularies/document#encodes": {
         "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.yaml#/encodes"
       },
-      "http://a.ml/vocabularies/document#version": "3.1.0",
       "http://a.ml/vocabularies/document#root": true,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.yaml/BaseUnitProcessingData"
+      },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16c.yaml#/source-map"
@@ -148,8 +168,10 @@
       "http://a.ml/vocabularies/document#encodes": {
         "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/encodes"
       },
-      "http://a.ml/vocabularies/document#version": "3.1.0",
       "http://a.ml/vocabularies/document#root": false,
+      "http://a.ml/vocabularies/document#processingData": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml/BaseUnitProcessingData"
+      },
       "http://a.ml/vocabularies/document-source-maps#sources": [
         {
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/source-map"
@@ -183,6 +205,19 @@
           "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/encodes/source-map"
         }
       ]
+    },
+    {
+      "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml/BaseUnitProcessingData",
+      "@type": [
+        "http://a.ml/vocabularies/document#DialectInstanceProcessingData"
+      ],
+      "http://a.ml/vocabularies/meta#definedBy": [
+        {
+          "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml"
+        }
+      ],
+      "http://a.ml/vocabularies/document#transformed": false,
+      "http://a.ml/vocabularies/document#sourceSpec": "TestInstance 1.16b"
     },
     {
       "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/example16b.yaml#/source-map",

--- a/amf-aml/shared/src/test/scala/amf/testing/common/utils/DialectRegistrationHelper.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/common/utils/DialectRegistrationHelper.scala
@@ -14,8 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait DialectRegistrationHelper {
   protected def withDialect[T](uri: String)(fn: (Dialect, AMLConfiguration) => Future[T])(
       implicit ec: ExecutionContext): Future[T] = {
-    val eh            = DefaultErrorHandler()
-    val configuration = AMLConfiguration.forEH(eh)
+    val configuration = AMLConfiguration.predefined()
     val context       = new CompilerContextBuilder(uri, platform, configuration.compilerConfiguration).build()
     for {
       baseUnit <- new AMFCompiler(context).build()

--- a/amf-aml/shared/src/test/scala/amf/testing/common/utils/DialectValidation.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/common/utils/DialectValidation.scala
@@ -21,8 +21,7 @@ trait DialectValidation extends AsyncFunSuite with PlatformSecrets {
                          jsonldReport: Boolean = true,
                          multiPlatform: Boolean = true): Future[Assertion] = {
 
-    val eh            = DefaultErrorHandler()
-    val configuration = AMLConfiguration.forEH(eh)
+    val configuration = AMLConfiguration.predefined()
     val client        = configuration.baseUnitClient()
     for {
       report    <- client.parseDialect("file://" + path + dialectPath).map(AMFValidationReport.unknownProfile(_))

--- a/amf-aml/shared/src/test/scala/amf/testing/parsing/DialectInstancesParsingTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/parsing/DialectInstancesParsingTest.scala
@@ -230,49 +230,59 @@ trait DialectInstancesParsingTest extends DialectTests {
                      renderOptions = Some(config.renderOptions))
   }
 
-  // TODO ARM forInstance metohd required
-//  multiGoldenTest("parse 15 test", "example15.%s") { config =>
-//    for {
-//      _ <- AMLPlugin.registry.registerDialect(
-//          "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect15b.yaml")
-//      assertion <- cycleWithDialect("dialect15a.yaml",
-//                                    "example15.yaml",
-//                                    config.golden,
-//                                    //                                    mediaType = Some(Mimes.`application/ld+json`,
-//                                    renderOptions = Some(config.renderOptions))
-//    } yield {
-//      assertion
-//    }
-//
-//  }
+  multiGoldenTest("parse 15 test", "example15.%s") { config =>
+    val amlConfig = AMLConfiguration.predefined()
+    for {
+      nextAmlConfig <- amlConfig.withDialect(
+          "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect15b.yaml")
+      assertion <- cycleWithDialect(
+          "dialect15a.yaml",
+          "example15.yaml",
+          config.golden,
+          renderOptions = Some(config.renderOptions),
+          mediaType = Some(Mimes.`application/ld+json`),
+          baseConfig = nextAmlConfig
+      )
+    } yield {
+      assertion
+    }
+  }
 
-  // TODO forInstance needed
-//  multiGoldenTest("parse 16 test", "example16a.%s") { config =>
-//    for {
-//      _ <- AMLPlugin.registry.registerDialect(s"file://$basePath/dialect16b.yaml")
-//      assertion <- cycleWithDialect("dialect16a.yaml",
-//                                    "example16a.yaml",
-//                                    config.golden,
-//                                    //                                    mediaType = Some(Mimes.`application/ld+json`,
-//                                    renderOptions = Some(config.renderOptions))
-//    } yield {
-//      assertion
-//    }
-//  }
+  multiGoldenTest("parse 16 test", "example16a.%s") { config =>
+    val amlConfig = AMLConfiguration.predefined()
+    for {
+      nextAmlConfig <- amlConfig.withDialect(
+          "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml")
+      assertion <- cycleWithDialect(
+          "dialect16a.yaml",
+          "example16a.yaml",
+          config.golden,
+          renderOptions = Some(config.renderOptions),
+          mediaType = Some(Mimes.`application/ld+json`),
+          baseConfig = nextAmlConfig
+      )
+    } yield {
+      assertion
+    }
+  }
 
-  // TODO forInstance needed
-  //  multiGoldenTest("parse 16 $include test", "example16c.%s") { config =>
-//    for {
-//      _ <- AMLPlugin.registry.registerDialect(s"file://$basePath/dialect16b.yaml")
-//      assertion <- cycleWithDialect("dialect16a.yaml",
-//                                    "example16c.yaml",
-//                                    config.golden,
-//                                    //                                    mediaType = Some(Mimes.`application/ld+json`,
-//                                    renderOptions = Some(config.renderOptions))
-//    } yield {
-//      assertion
-//    }
-//  }
+  multiGoldenTest("parse 16 $include test", "example16c.%s") { config =>
+    val amlConfig = AMLConfiguration.predefined()
+    for {
+      nextAmlConfig <- amlConfig.withDialect(
+          "file://amf-aml/shared/src/test/resources/vocabularies2/instances/dialect16b.yaml")
+      assertion <- cycleWithDialect(
+          "dialect16a.yaml",
+          "example16c.yaml",
+          config.golden,
+          renderOptions = Some(config.renderOptions),
+          mediaType = Some(Mimes.`application/ld+json`),
+          baseConfig = nextAmlConfig
+      )
+    } yield {
+      assertion
+    }
+  }
 
   multiGoldenTest("parse 17 test", "example17.output.%s") { config =>
     cycleWithDialect("dialect17.input.json",

--- a/amf-aml/shared/src/test/scala/amf/testing/parsing/DialectsParsingTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/parsing/DialectsParsingTest.scala
@@ -248,35 +248,6 @@ trait DialectsParsingTest extends DialectTests {
     cycle(config.source, "referencestyle/example19-referencestyle.yaml", mediaType = Some(Mimes.`application/yaml`))
   }
 
-  // TODO: ARM meaningless test - delete
-//  test("generate 20 test - without version") {
-//    val preRegistry = AMLPlugin().registry.allDialects().size
-//    for {
-//      b <- parse(s"file://$basePath/invalid/example20-no-version.yaml",
-//                 platform,
-//                 VocabularyYamlHint,
-//                 AMLConfiguration.predefined())
-//    } yield {
-//      assert(AMLPlugin().registry.allDialects().size == preRegistry)
-//      assert(AMLPlugin().registry.dialectById(b.id).isEmpty)
-//    }
-//  }
-
-  // TODO: ARM meaningless test - delete
-//  test("generate 21 test - without name") {
-//
-//    val preRegistry = AMLPlugin().registry.allDialects().size
-//    for {
-//      b <- parse(s"file://$basePath/invalid/example21-no-name.yaml",
-//                 platform,
-//                 VocabularyYamlHint,
-//                 AMLConfiguration.predefined())
-//    } yield {
-//      assert(AMLPlugin().registry.allDialects().size == preRegistry)
-//      assert(AMLPlugin().registry.dialectById(b.id).isEmpty)
-//    }
-//  }
-
   multiGoldenTest("Parse dialect with fragment", "dialect.%s") { config =>
     cycle("dialect.yaml",
           config.golden,

--- a/amf-aml/shared/src/test/scala/amf/testing/validation/VocabularyDefinitionValidationTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/validation/VocabularyDefinitionValidationTest.scala
@@ -43,14 +43,10 @@ class VocabularyDefinitionValidationTest
     validate("vocabulary.yaml", Some("validation.jsonld"), "missing-property-term")
   }
 
-  private def compilerContext(url: String, amfConfig: AMLConfiguration) =
-    new CompilerContextBuilder(url, platform, amfConfig.compilerConfiguration).build()
-
   protected def validate(vocabulary: String,
                          goldenReport: Option[String] = None,
                          path: String): Future[scalatest.Assertion] = {
-    val eh            = DefaultErrorHandler()
-    val configuration = AMLConfiguration.forEH(eh)
+    val configuration = AMLConfiguration.predefined()
     val report = for {
       report <- configuration
         .baseUnitClient()

--- a/amf-rdf/shared/src/main/scala/amf/rdf/client/scala/RdfSyntaxPlugin.scala
+++ b/amf-rdf/shared/src/main/scala/amf/rdf/client/scala/RdfSyntaxPlugin.scala
@@ -12,7 +12,6 @@ object RdfSyntaxPlugin extends AMFSyntaxParsePlugin with RdfPlatformSecrets {
 
   override val id = "Rdf"
 
-  // TODO ARM to render syntax plugin
   def unparse[W: Output](mediaType: String, doc: ParsedDocument, writer: W): Option[W] =
     (doc, framework) match {
       case (input: RdfModelDocument, r) => r.rdfModelToSyntaxWriter(mediaType, input, writer)


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/352

- Cleanup: Clarified comment
- Cleanup: Removed factory method in AMLConfiguration
- Added specific exception in case the AML parse plugins don't recognize the document header
- Added event when AML validation is skipped
- Test: uncommented and updated forInstance related tests
- Removed obsolete TODOs, changed others because they go beyond remod
