### PR TITLE
APIMF-3519: added componentId as an empty component id was normalized when used in adoption resulting in duplicate ids (Semantic Extensions)

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/aml/client/scala/model/domain/DialectDomainElement.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/scala/model/domain/DialectDomainElement.scala
@@ -192,7 +192,7 @@ case class DialectDomainElement(override val fields: Fields, annotations: Annota
   private[amf] def literalProperty(f: Field): Option[Any]                        = literalProperties(f).headOption
   private[amf] def literalProperties(f: Field): Seq[Any]                         = graph.scalarByField(f)
 
-  private[amf] override def componentId: String = ""
+  private[amf] override def componentId: String = "element"
 
   private def setObjInCollection(f: Field, node: Either[YNode, YMapEntry], newObj: DialectDomainElement) = {
     val (annotations, _)                = getAnnotationsOf(node)


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/379
﻿
