### PR TITLE
APIMF-3581

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/aml/client/scala/render/AmlDomainElementEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/scala/render/AmlDomainElementEmitter.scala
@@ -9,7 +9,9 @@ import amf.core.client.scala.model.domain.DomainElement
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters.DomainElementEmitter
 import amf.aml.internal.annotations.DiscriminatorField
+import amf.aml.internal.registries.AMLRegistry
 import amf.aml.internal.render.emitters.instances.{DefaultNodeMappableFinder, DialectNodeEmitter}
+import amf.core.internal.registries.AMFRegistry
 import org.yaml.model.YNode
 
 object AmlDomainElementEmitter extends DomainElementEmitter[Dialect] {
@@ -21,16 +23,19 @@ object AmlDomainElementEmitter extends DomainElementEmitter[Dialect] {
                     emissionStructure: Dialect,
                     eh: AMFErrorHandler,
                     references: Seq[BaseUnit] = Nil): YNode = {
+
     val partEmitter = element match {
-      case element: DialectDomainElement => Some(dialectDomainElementEmitter(emissionStructure, references, element))
-      case _                             => None
+      case element: DialectDomainElement =>
+        Some(dialectDomainElementEmitter(emissionStructure, references, element, AMLRegistry.empty))
+      case _ => None
     }
     nodeOrError(partEmitter, element.id, eh)
   }
 
   private def dialectDomainElementEmitter(dialect: Dialect,
                                           references: Seq[BaseUnit],
-                                          element: DialectDomainElement) = {
+                                          element: DialectDomainElement,
+                                          registry: AMLRegistry) = {
     val renderOptions = RenderOptions()
     val nodeMappable  = element.definedBy
     val discriminator = element.annotations.find(classOf[DiscriminatorField]).map(a => a.key -> a.value)
@@ -42,6 +47,7 @@ object AmlDomainElementEmitter extends DomainElementEmitter[Dialect] {
                        dialect,
                        SpecOrdering.Lexical,
                        discriminator = discriminator,
-                       renderOptions = renderOptions)(finder)
+                       renderOptions = renderOptions,
+                       registry = registry)(finder)
   }
 }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/registries/AMLRegistry.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/registries/AMLRegistry.scala
@@ -130,4 +130,10 @@ object AMLRegistry {
         Map.empty,
         registry.getNamespaceAliases
     )
+
+  def apply(registry: AMFRegistry, dialects: Seq[Dialect]): AMLRegistry = {
+    dialects.foldLeft(AMLRegistry(registry)) { (acc, curr) =>
+      acc.withExtensions(curr)
+    }
+  }
 }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/AmlEmittersHelper.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/AmlEmittersHelper.scala
@@ -17,6 +17,7 @@ import amf.aml.client.scala.model.domain.{NodeMappable, NodeMapping, UnionNodeMa
 import org.yaml.model.YDocument.EntryBuilder
 import amf.core.internal.utils.Regexes.Path
 import amf.aml.client.scala.model.domain.NodeMappable.AnyNodeMappable
+import org.mulesoft.common.collections.FilterType
 import org.mulesoft.common.core.CachedFunction
 import org.mulesoft.common.functional.MonadInstances.identityMonad
 
@@ -27,6 +28,7 @@ trait NodeMappableFinder {
 }
 
 object DefaultNodeMappableFinder {
+  def apply(dialect: Dialect)       = new DefaultNodeMappableFinder(computeReferencesTree(dialect))
   def apply(dialects: Seq[Dialect]) = new DefaultNodeMappableFinder(dialects)
   def apply(ctx: ParserContext) = {
     val knownDialects = ctx.config.sortedRootParsePlugins.collect {
@@ -34,11 +36,27 @@ object DefaultNodeMappableFinder {
     }
     new DefaultNodeMappableFinder(knownDialects)
   }
+
   def apply(config: AMLConfiguration) = {
     val knownDialects = config.configurationState().getDialects()
     new DefaultNodeMappableFinder(knownDialects)
   }
+
   def empty() = new DefaultNodeMappableFinder(Seq.empty)
+
+  private def computeReferencesTree(from: Dialect): List[Dialect] = {
+    val collector = mutable.Map[String, Dialect]()
+    computeReferencesTree(from, collector)
+    collector.values.toList
+  }
+
+  private def computeReferencesTree(from: Dialect, acc: mutable.Map[String, Dialect]): Unit = {
+    acc.put(from.id, from)
+    from.references
+      .filterType[Dialect]
+      .filter(dialect => !acc.contains(dialect.id))
+      .foreach(dialect => computeReferencesTree(dialect, acc))
+  }
 }
 
 case class DefaultNodeMappableFinder(dialects: Seq[Dialect]) extends NodeMappableFinder {

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/CustomDomainPropertiesEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/CustomDomainPropertiesEmitter.scala
@@ -24,12 +24,7 @@ object CustomDomainPropertiesEmitter {
         customDomainProperties.flatMap {
           case extension: DomainExtension if Option(extension.extension).isEmpty =>
             val name = extensionSyntax(extension.name.value())
-            SemanticExtensionsFacade(registry).render(name,
-                                                      extension,
-                                                      node.meta.typeIri,
-                                                      ordering,
-                                                      renderOptions,
-                                                      nodeMappableFinder)
+            SemanticExtensionsFacade(registry).render(name, extension, node.meta.typeIri, ordering, renderOptions)
           case domainExtension: DomainExtension => emitScalarExtension(domainExtension)
         }
       case _ => Nil

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/CustomDomainPropertiesEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/CustomDomainPropertiesEmitter.scala
@@ -1,27 +1,42 @@
 package amf.aml.internal.render.emitters.instances
 
 import amf.aml.client.scala.model.domain.DialectDomainElement
+import amf.aml.internal.registries.AMLRegistry
+import amf.aml.internal.semantic.SemanticExtensionsFacade
 import amf.core.client.common.position.Position
+import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.model.DataType
 import amf.core.client.scala.model.domain.extensions.DomainExtension
 import amf.core.client.scala.model.domain.{AmfArray, ScalarNode}
 import amf.core.internal.metamodel.domain.DomainElementModel
 import amf.core.internal.render.BaseEmitters.{MapEntryEmitter, pos}
+import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters.EntryEmitter
 import org.yaml.model.YDocument.EntryBuilder
 import org.yaml.model.{YDocument, YType}
 
 object CustomDomainPropertiesEmitter {
 
-  def apply(node: DialectDomainElement): Seq[EntryEmitter] = {
+  def apply(node: DialectDomainElement, registry: AMLRegistry, ordering: SpecOrdering, renderOptions: RenderOptions)(
+      implicit nodeMappableFinder: NodeMappableFinder): Seq[EntryEmitter] = {
     node.fields.get(DomainElementModel.CustomDomainProperties) match {
       case AmfArray(customDomainProperties, _) =>
         customDomainProperties.flatMap {
+          case extension: DomainExtension if Option(extension.extension).isEmpty =>
+            val name = extensionSyntax(extension.name.value())
+            SemanticExtensionsFacade(registry).render(name,
+                                                      extension,
+                                                      node.meta.typeIri,
+                                                      ordering,
+                                                      renderOptions,
+                                                      nodeMappableFinder)
           case domainExtension: DomainExtension => emitScalarExtension(domainExtension)
         }
       case _ => Nil
     }
   }
+
+  private def extensionSyntax(name: String): String = s"($name)"
 
   private def emitScalarExtension(extension: DomainExtension): Seq[EntryEmitter] = {
     val extensionName = extension.name.value()

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/CustomDomainPropertiesEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/CustomDomainPropertiesEmitter.scala
@@ -1,0 +1,48 @@
+package amf.aml.internal.render.emitters.instances
+
+import amf.aml.client.scala.model.domain.DialectDomainElement
+import amf.core.client.common.position.Position
+import amf.core.client.scala.model.DataType
+import amf.core.client.scala.model.domain.extensions.DomainExtension
+import amf.core.client.scala.model.domain.{AmfArray, ScalarNode}
+import amf.core.internal.metamodel.domain.DomainElementModel
+import amf.core.internal.render.BaseEmitters.{MapEntryEmitter, pos}
+import amf.core.internal.render.emitters.EntryEmitter
+import org.yaml.model.YDocument.EntryBuilder
+import org.yaml.model.{YDocument, YType}
+
+object CustomDomainPropertiesEmitter {
+
+  def apply(node: DialectDomainElement): Seq[EntryEmitter] = {
+    node.fields.get(DomainElementModel.CustomDomainProperties) match {
+      case AmfArray(customDomainProperties, _) =>
+        customDomainProperties.flatMap {
+          case domainExtension: DomainExtension => emitScalarExtension(domainExtension)
+        }
+      case _ => Nil
+    }
+  }
+
+  private def emitScalarExtension(extension: DomainExtension): Seq[EntryEmitter] = {
+    val extensionName = extension.name.value()
+    extension.`extension` match {
+      case s: ScalarNode =>
+        val extensionValue = s.value.value()
+        val tagType        = dataTypeToYamlType(s)
+        val position       = pos(extension.annotations)
+        Seq(MapEntryEmitter(extensionName, extensionValue, tag = tagType, position = position))
+      case _ => Nil
+    }
+  }
+
+  private def dataTypeToYamlType(s: ScalarNode) = {
+    s.dataType.value() match {
+      case DataType.Integer  => YType.Int
+      case DataType.Float    => YType.Float
+      case DataType.Boolean  => YType.Bool
+      case DataType.Nil      => YType.Null
+      case DataType.DateTime => YType.Timestamp
+      case _                 => YType.Str
+    }
+  }
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DeclarationsGroupEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DeclarationsGroupEmitter.scala
@@ -6,16 +6,12 @@ import amf.core.client.common.position.Position
 import amf.core.client.common.position.Position.ZERO
 import amf.core.internal.render.SpecOrdering
 import amf.aml.client.scala.model.document.{Dialect, DialectInstanceUnit}
-import amf.aml.client.scala.model.domain.{
-  DialectDomainElement,
-  NodeMappable,
-  PublicNodeMapping,
-  UnionNodeMapping
-}
+import amf.aml.client.scala.model.domain.{DialectDomainElement, NodeMappable, PublicNodeMapping, UnionNodeMapping}
 import org.yaml.model.YDocument.EntryBuilder
 import org.yaml.model.YNode
 import amf.core.internal.utils.AmfStrings
 import amf.aml.internal.metamodel.domain.NodeMappableModel
+import amf.aml.internal.registries.AMLRegistry
 
 case class DeclarationsGroupEmitter(declared: Seq[DialectDomainElement],
                                     publicNodeMapping: PublicNodeMapping,
@@ -26,7 +22,8 @@ case class DeclarationsGroupEmitter(declared: Seq[DialectDomainElement],
                                     declarationsPath: Seq[String],
                                     aliases: Map[String, (String, String)],
                                     keyPropertyId: Option[String] = None,
-                                    renderOptions: RenderOptions)(implicit val nodeMappableFinder: NodeMappableFinder)
+                                    renderOptions: RenderOptions,
+                                    registry: AMLRegistry)(implicit val nodeMappableFinder: NodeMappableFinder)
     extends EntryEmitter
     with AmlEmittersHelper {
 
@@ -68,7 +65,8 @@ case class DeclarationsGroupEmitter(declared: Seq[DialectDomainElement],
                                        dialect,
                                        ordering,
                                        discriminator = discriminatorProperty,
-                                       renderOptions = renderOptions).emit(b)
+                                       renderOptions = renderOptions,
+                                       registry = registry).emit(b)
                   }
               )
             }
@@ -87,7 +85,8 @@ case class DeclarationsGroupEmitter(declared: Seq[DialectDomainElement],
                                      declarationsPath.tail,
                                      aliases,
                                      keyPropertyId,
-                                     renderOptions).emit(b)
+                                     renderOptions,
+                                     registry).emit(b)
           }
       )
     }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectDomainElementLinkEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectDomainElementLinkEmitter.scala
@@ -1,0 +1,56 @@
+package amf.aml.internal.render.emitters.instances
+
+import amf.aml.client.scala.model.document.DialectInstanceFragment
+import amf.aml.client.scala.model.domain.DialectDomainElement
+import amf.aml.internal.annotations.{JsonPointerRef, RefInclude}
+import amf.core.client.common.position.Position
+import amf.core.client.common.position.Position.ZERO
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.internal.annotations.{LexicalInformation, SourceNode}
+import amf.core.internal.render.BaseEmitters.TextScalarEmitter
+import amf.core.internal.render.emitters.PartEmitter
+import org.yaml.model.YDocument.PartBuilder
+import org.yaml.model.{YNode, YType}
+
+case class DialectDomainElementLinkEmitter(node: DialectDomainElement, references: Seq[BaseUnit]) extends PartEmitter {
+  override def emit(b: PartBuilder): Unit = {
+    if (node.annotations.contains(classOf[RefInclude])) {
+      b.obj { m =>
+        m.entry("$include", node.includeName)
+      }
+    } else if (node.annotations.contains(classOf[JsonPointerRef])) {
+      b.obj { m =>
+        m.entry("$ref", node.linkLabel.option().getOrElse(node.linkTarget.get.id))
+      }
+    } else if (isFragmentRef(node, references)) {
+      b += YNode.include(node.includeName)
+    } else {
+      // case of library and declaration references
+      TextScalarEmitter(node.linkLabel.value(), node.annotations).emit(b)
+    }
+  }
+
+  def isFragmentRef(elem: DialectDomainElement, references: Seq[BaseUnit]): Boolean = {
+    elem.annotations.find(classOf[SourceNode]) match {
+      case Some(SourceNode(node)) => node.tagType == YType.Include
+      case None if references.nonEmpty =>
+        elem.linkTarget match {
+          case Some(domainElement) =>
+            references.exists {
+              case ref: DialectInstanceFragment =>
+                ref.encodes.id == domainElement.id
+              case _ => false
+            }
+          case _ =>
+            throw new Exception(s"Cannot check fragment for an element without target for element ${elem.id}")
+        }
+      case _ => false
+    }
+  }
+
+  override def position(): Position =
+    node.annotations
+      .find(classOf[LexicalInformation])
+      .map(_.range.start)
+      .getOrElse(ZERO)
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectInstancesEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectInstancesEmitter.scala
@@ -9,11 +9,14 @@ import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.SpecOrdering.Lexical
 import amf.aml.client.scala.model.document._
 import amf.aml.client.scala.model.domain._
+import amf.aml.internal.registries.AMLRegistry
 import org.yaml.model.YDocument
 import org.yaml.model.YDocument.PartBuilder
 
-case class DialectInstancesEmitter(instance: DialectInstanceUnit, dialect: Dialect, renderOptions: RenderOptions)(
-    implicit val nodeMappableFinder: NodeMappableFinder)
+case class DialectInstancesEmitter(instance: DialectInstanceUnit,
+                                   dialect: Dialect,
+                                   renderOptions: RenderOptions,
+                                   registry: AMLRegistry)(implicit val nodeMappableFinder: NodeMappableFinder)
     extends AmlEmittersHelper {
 
   val ordering: SpecOrdering                           = Lexical
@@ -67,7 +70,8 @@ case class DialectInstancesEmitter(instance: DialectInstanceUnit, dialect: Diale
         None,
         topLevelEmitters = externalEmitters(instance, ordering) ++ entry,
         discriminator = discriminator.flatMap(_.compute(element)),
-        renderOptions = renderOptions
+        renderOptions = renderOptions,
+        registry = registry
     ).emit(b)
   }
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectNodeEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectNodeEmitter.scala
@@ -172,35 +172,7 @@ case class DialectNodeEmitter(node: DialectDomainElement,
   private def fieldAndExtensionEmitters: Seq[EntryEmitter] = {
     var emitters: Seq[EntryEmitter] = Nil
     uniqueFields(node.meta).foreach {
-      case DomainElementModel.CustomDomainProperties =>
-        node.fields.get(DomainElementModel.CustomDomainProperties) match {
-          case AmfArray(customDomainProperties, _) =>
-            customDomainProperties.foreach {
-              case domainExtension: DomainExtension =>
-                val extensionName = domainExtension.name.value()
-                domainExtension.`extension` match {
-                  case s: ScalarNode =>
-                    val extensionValue = s.value.value()
-                    val tagType = s.dataType.value() match {
-                      case DataType.Integer  => YType.Int
-                      case DataType.Float    => YType.Float
-                      case DataType.Boolean  => YType.Bool
-                      case DataType.Nil      => YType.Null
-                      case DataType.DateTime => YType.Timestamp
-                      case _                 => YType.Str
-                    }
-                    val position = domainExtension.annotations
-                      .find(classOf[LexicalInformation])
-                      .map(_.range.start)
-                      .getOrElse(Position.ZERO)
-                    emitters ++= Seq(
-                        MapEntryEmitter(extensionName, extensionValue, tag = tagType, position = position))
-                  case _ => // Ignore
-                }
-
-            }
-          case _ => // Ignore
-        }
+      case DomainElementModel.CustomDomainProperties => emitters ++= CustomDomainPropertiesEmitter(node)
 
       case field =>
         findPropertyMapping(node, field) foreach { propertyMapping =>

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectNodeEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectNodeEmitter.scala
@@ -175,78 +175,82 @@ case class DialectNodeEmitter(node: DialectDomainElement,
       case DomainElementModel.CustomDomainProperties => emitters ++= CustomDomainPropertiesEmitter(node)
 
       case field =>
-        findPropertyMapping(node, field) foreach { propertyMapping =>
-          if (keyPropertyId.isEmpty || propertyMapping
-                .nodePropertyMapping()
-                .value() != keyPropertyId.get) {
-
-            val key                    = propertyMapping.name().value()
-            val propertyClassification = propertyMapping.classification()
-
-            val nextEmitter: Seq[EntryEmitter] =
-              node.fields.getValueAsOption(field) match {
-                case Some(entry) if isScalar(entry) =>
-                  val scalar = entry.value.asInstanceOf[AmfScalar]
-                  emitScalar(key, field, scalar, Some(entry.annotations))
-
-                case Some(entry) if isArray(entry) && propertyClassification == LiteralPropertyCollection =>
-                  val array = entry.value.asInstanceOf[AmfArray]
-                  emitScalarArray(key, field, array, Some(entry.annotations))
-
-                case Some(entry)
-                    if entry.value
-                      .isInstanceOf[DialectDomainElement] && propertyClassification == ExtensionPointProperty =>
-                  val element = entry.value.asInstanceOf[DialectDomainElement]
-                  emitExternalObject(key, element, propertyMapping)
-
-                case Some(entry)
-                    if entry.value
-                      .isInstanceOf[DialectDomainElement] && propertyClassification == ExternalLinkProperty =>
-                  val element = entry.value.asInstanceOf[DialectDomainElement]
-                  emitExternalLink(key, element, propertyMapping)
-
-                case Some(entry)
-                    if entry.value
-                      .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && !propertyMapping.isUnion =>
-                  val element = entry.value.asInstanceOf[DialectDomainElement]
-                  val result  = emitObjectEntry(key, element, propertyMapping, Some(entry.annotations))
-                  result
-
-                case Some(entry) if isArray(entry) && propertyClassification == ExternalLinkProperty =>
-                  val array = entry.value.asInstanceOf[AmfArray]
-                  emitExternalLink(key, array, propertyMapping, Some(entry.annotations))
-
-                case Some(entry)
-                    if isArray(entry) && propertyClassification == ObjectPropertyCollection && !propertyMapping.isUnion =>
-                  val array = entry.value.asInstanceOf[AmfArray]
-                  emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
-
-                case Some(entry) if isArray(entry) && propertyClassification == ObjectMapProperty =>
-                  val array = entry.value.asInstanceOf[AmfArray]
-                  emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
-
-                case Some(entry)
-                    if entry.value
-                      .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && propertyMapping.isUnion =>
-                  val element = entry.value.asInstanceOf[DialectDomainElement]
-                  emitObjectEntry(key, element, propertyMapping)
-
-                case Some(entry)
-                    if isArray(entry) && propertyClassification == ObjectPropertyCollection && propertyMapping.isUnion =>
-                  val array = entry.value.asInstanceOf[AmfArray]
-                  emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
-
-                case Some(entry) if isArray(entry) && propertyClassification == ObjectPairProperty =>
-                  val array = entry.value.asInstanceOf[AmfArray]
-                  emitObjectPairs(key, array, propertyMapping, Some(entry.annotations))
-                case None => Nil // ignore
-              }
-            emitters ++= nextEmitter
-          }
-        }
+        emitters ++= emitField(field)
     }
     emitters
   }
+
+  private def emitField(field: Field): Seq[EntryEmitter] = {
+    findPropertyMapping(node, field) map { propertyMapping =>
+      if (keyPropertyId.isEmpty || propertyMapping
+            .nodePropertyMapping()
+            .value() != keyPropertyId.get) {
+
+        val key                    = propertyMapping.name().value()
+        val propertyClassification = propertyMapping.classification()
+
+        val nextEmitter: Seq[EntryEmitter] =
+          node.fields.getValueAsOption(field) match {
+            case Some(entry) if isScalar(entry) =>
+              val scalar = entry.value.asInstanceOf[AmfScalar]
+              emitScalar(key, field, scalar, Some(entry.annotations))
+
+            case Some(entry) if isArray(entry) && propertyClassification == LiteralPropertyCollection =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitScalarArray(key, field, array, Some(entry.annotations))
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ExtensionPointProperty =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              emitExternalObject(key, element, propertyMapping)
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ExternalLinkProperty =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              emitExternalLink(key, element, propertyMapping)
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && !propertyMapping.isUnion =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              val result  = emitObjectEntry(key, element, propertyMapping, Some(entry.annotations))
+              result
+
+            case Some(entry) if isArray(entry) && propertyClassification == ExternalLinkProperty =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitExternalLink(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry)
+                if isArray(entry) && propertyClassification == ObjectPropertyCollection && !propertyMapping.isUnion =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry) if isArray(entry) && propertyClassification == ObjectMapProperty =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && propertyMapping.isUnion =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              emitObjectEntry(key, element, propertyMapping)
+
+            case Some(entry)
+                if isArray(entry) && propertyClassification == ObjectPropertyCollection && propertyMapping.isUnion =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry) if isArray(entry) && propertyClassification == ObjectPairProperty =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectPairs(key, array, propertyMapping, Some(entry.annotations))
+            case None => Nil // ignore
+          }
+        nextEmitter
+      } else Nil
+    }
+  }.getOrElse(Nil)
 
   private def isArray(entry: Value) = {
     entry.value

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectObjectEntryEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/DialectObjectEntryEmitter.scala
@@ -1,0 +1,129 @@
+package amf.aml.internal.render.emitters.instances
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.client.scala.model.domain.{DialectDomainElement, NodeMapping, PropertyMapping}
+import amf.core.client.common.position.Position
+import amf.core.client.common.position.Position.ZERO
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.client.scala.model.domain.{AmfArray, AmfElement}
+import amf.core.internal.annotations.LexicalInformation
+import amf.core.internal.parser.domain.Annotations
+import amf.core.internal.render.BaseEmitters.EntryPartEmitter
+import amf.core.internal.render.SpecOrdering
+import amf.core.internal.render.emitters.EntryEmitter
+import org.yaml.model.YDocument.EntryBuilder
+
+private case class DialectObjectEntryEmitter(
+    key: String,
+    target: AmfElement,
+    propertyMapping: PropertyMapping,
+    references: Seq[BaseUnit],
+    dialect: Dialect,
+    ordering: SpecOrdering,
+    renderOptions: RenderOptions,
+    annotations: Option[Annotations] = None)(implicit val nodeMappableFinder: NodeMappableFinder)
+    extends EntryEmitter
+    with AmlEmittersHelper {
+  // this can be multiple mappings if we have a union in the range or a range pointing to a union mapping
+  val nodeMappings: Seq[NodeMapping] =
+    propertyMapping.objectRange().flatMap { rangeNodeMapping =>
+      findAllNodeMappings(rangeNodeMapping.value())
+    }
+
+  // val key property id, so we can pass it to the nested emitter and it is not emitted
+  val keyPropertyId: Option[String] = propertyMapping.mapTermKeyProperty().option()
+
+  // lets first extract the target values to emit, always as an array
+  val elements: Seq[DialectDomainElement] = target match {
+    case array: AmfArray =>
+      array.values.asInstanceOf[Seq[DialectDomainElement]]
+    case element: DialectDomainElement => Seq(element)
+  }
+
+  val isArray: Boolean = target.isInstanceOf[AmfArray]
+  val discriminator: DiscriminatorHelper =
+    DiscriminatorHelper(propertyMapping, this)
+
+  override def emit(b: EntryBuilder): Unit = {
+    // collect the emitters for each element, based on the available mappings
+    val mappedElements: Map[DialectNodeEmitter, DialectDomainElement] =
+      elements.foldLeft(Map[DialectNodeEmitter, DialectDomainElement]()) {
+        case (acc, dialectDomainElement: DialectDomainElement) =>
+          // Let's see if this element has a discriminator to add
+          nodeMappings.find(
+              nodeMapping =>
+                dialectDomainElement.meta.`type`
+                  .map(_.iri())
+                  .contains(nodeMapping.nodetypeMapping.value())) match {
+            case Some(nextNodeMapping) =>
+              val nodeEmitter = DialectNodeEmitter(
+                  dialectDomainElement,
+                  nextNodeMapping,
+                  references,
+                  dialect,
+                  ordering,
+                  discriminator = discriminator.compute(dialectDomainElement),
+                  keyPropertyId = keyPropertyId,
+                  renderOptions = renderOptions
+              )
+              acc + (nodeEmitter -> dialectDomainElement)
+            case _ =>
+              acc // TODO: raise violation
+          }
+        case (acc, _) => acc
+      }
+
+    if (keyPropertyId.isDefined) {
+      // emit map of nested objects by property
+      emitMap(b, mappedElements)
+    } else if (isArray) {
+      // arrays of objects
+      emitArray(b, mappedElements)
+    } else {
+      // single object
+      emitSingleElement(b, mappedElements)
+    }
+  }
+
+  def emitMap(b: EntryBuilder, mapElements: Map[DialectNodeEmitter, DialectDomainElement]): Unit = {
+    b.entry(
+        key,
+        _.obj { b =>
+          ordering.sorted(mapElements.keys.toSeq).foreach { emitter =>
+            val dialectDomainElement = mapElements(emitter)
+            val mapKeyField =
+              dialectDomainElement.meta.fields
+                .find(_.value
+                  .iri() == propertyMapping.mapTermKeyProperty().value())
+                .get
+            val mapKeyValue =
+              dialectDomainElement.fields.getValue(mapKeyField).toString
+            EntryPartEmitter(mapKeyValue, emitter).emit(b)
+          }
+        }
+    )
+  }
+
+  def emitArray(b: EntryBuilder, mappedElements: Map[DialectNodeEmitter, DialectDomainElement]): Unit = {
+    b.entry(key, _.list { b =>
+      ordering.sorted(mappedElements.keys.toSeq).foreach(_.emit(b))
+    })
+  }
+
+  def emitSingleElement(b: EntryBuilder, mappedElements: Map[DialectNodeEmitter, DialectDomainElement]): Unit = {
+    mappedElements.keys.headOption.foreach { emitter =>
+      EntryPartEmitter(key, emitter).emit(b)
+    }
+  }
+
+  override def position(): Position = {
+
+    annotations
+      .flatMap(_.find(classOf[LexicalInformation]))
+      .orElse(target.annotations.find(classOf[LexicalInformation]))
+      .map(_.range.start)
+      .getOrElse(ZERO)
+  }
+
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/ExternalLinkEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/ExternalLinkEmitter.scala
@@ -1,0 +1,112 @@
+package amf.aml.internal.render.emitters.instances
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.client.scala.model.domain.{DialectDomainElement, NodeMapping, PropertyMapping}
+import amf.aml.internal.annotations.{CustomBase, CustomId}
+import amf.core.client.common.position.Position
+import amf.core.client.common.position.Position.ZERO
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.client.scala.model.domain.{AmfArray, AmfElement}
+import amf.core.internal.annotations.LexicalInformation
+import amf.core.internal.parser.domain.Annotations
+import amf.core.internal.render.SpecOrdering
+import amf.core.internal.render.emitters.EntryEmitter
+import org.yaml.model.YDocument
+import org.yaml.model.YDocument.PartBuilder
+
+case class ExternalLinkEmitter(key: String,
+                               dialect: Dialect,
+                               target: AmfElement,
+                               propertyMapping: PropertyMapping,
+                               annotations: Option[Annotations] = None,
+                               keyPropertyId: Option[String] = None,
+                               references: Seq[BaseUnit],
+                               ordering: SpecOrdering,
+                               renderOptions: RenderOptions)(implicit val nodeMappableFinder: NodeMappableFinder)
+    extends EntryEmitter
+    with AmlEmittersHelper {
+  override def emit(b: YDocument.EntryBuilder): Unit = {
+    b.entry(
+        key,
+        (e) => {
+          target match {
+            case array: AmfArray =>
+              e.list(l => {
+                array.values.asInstanceOf[Seq[DialectDomainElement]].foreach {
+                  elem =>
+                    if (elem.fields.nonEmpty) { // map reference
+                      nodeMappingForObjectProperty(propertyMapping, elem) match {
+                        case Some(rangeMapping) =>
+                          DialectNodeEmitter(
+                              elem,
+                              rangeMapping,
+                              references,
+                              dialect,
+                              ordering,
+                              discriminator = None,
+                              keyPropertyId = keyPropertyId,
+                              renderOptions = renderOptions
+                          ).emit(l)
+                        case _ => // ignore, error
+                      }
+                    } else { // just link
+                      emitCustomId(elem, l)
+                      emitCustomBase(elem, l)
+                    }
+                }
+              })
+            case element: DialectDomainElement =>
+              emitCustomId(element, e)
+              emitCustomBase(element, e)
+          }
+        }
+    )
+  }
+
+  protected def nodeMappingForObjectProperty(propertyMapping: PropertyMapping,
+                                             dialectDomainElement: DialectDomainElement): Option[NodeMappable] = {
+    // this can be multiple mappings if we have a union in the range or a range pointing to a union mapping
+    val nodeMappings: Seq[NodeMapping] =
+      propertyMapping.objectRange().flatMap { rangeNodeMapping =>
+        findAllNodeMappings(rangeNodeMapping.value())
+      }
+    nodeMappings.find(
+        nodeMapping =>
+          dialectDomainElement.meta.`type`
+            .map(_.iri())
+            .exists(i => i == nodeMapping.nodetypeMapping.value() || i == nodeMapping.id))
+  }
+
+  private def emitCustomId(elem: DialectDomainElement, b: PartBuilder): Unit = {
+    elem.annotations.find(classOf[CustomId]) match {
+      case Some(customId) if customId.value != "true" =>
+        b.obj { m =>
+          m.entry("$id", customId.value)
+        }
+      case Some(_) =>
+        b.obj { m =>
+          m.entry("$id", elem.id)
+        }
+      case _ => b += elem.id
+    }
+  }
+
+  private def emitCustomBase(elem: DialectDomainElement, b: PartBuilder): Unit = {
+    elem.annotations.find(classOf[CustomBase]) match {
+      case Some(customBase) if customBase.value != "true" =>
+        b.obj { m =>
+          m.entry("$base", customBase.value)
+        }
+      case _ => // Nothing
+    }
+  }
+
+  override def position(): Position = {
+    annotations
+      .flatMap(_.find(classOf[LexicalInformation]))
+      .orElse(target.annotations.find(classOf[LexicalInformation]))
+      .map(_.range.start)
+      .getOrElse(ZERO)
+  }
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/ExternalLinkEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/ExternalLinkEmitter.scala
@@ -1,8 +1,10 @@
 package amf.aml.internal.render.emitters.instances
 
 import amf.aml.client.scala.model.document.Dialect
-import amf.aml.client.scala.model.domain.{DialectDomainElement, NodeMapping, PropertyMapping}
+import amf.aml.client.scala.model.domain.{DialectDomainElement, NodeMapping, PropertyLikeMapping, PropertyMapping}
 import amf.aml.internal.annotations.{CustomBase, CustomId}
+import amf.aml.internal.metamodel.domain.PropertyLikeMappingModel
+import amf.aml.internal.registries.AMLRegistry
 import amf.core.client.common.position.Position
 import amf.core.client.common.position.Position.ZERO
 import amf.core.client.scala.config.RenderOptions
@@ -15,15 +17,17 @@ import amf.core.internal.render.emitters.EntryEmitter
 import org.yaml.model.YDocument
 import org.yaml.model.YDocument.PartBuilder
 
-case class ExternalLinkEmitter(key: String,
-                               dialect: Dialect,
-                               target: AmfElement,
-                               propertyMapping: PropertyMapping,
-                               annotations: Option[Annotations] = None,
-                               keyPropertyId: Option[String] = None,
-                               references: Seq[BaseUnit],
-                               ordering: SpecOrdering,
-                               renderOptions: RenderOptions)(implicit val nodeMappableFinder: NodeMappableFinder)
+case class ExternalLinkEmitter[M <: PropertyLikeMappingModel](
+    key: String,
+    dialect: Dialect,
+    target: AmfElement,
+    propertyMapping: PropertyLikeMapping[M],
+    annotations: Option[Annotations] = None,
+    keyPropertyId: Option[String] = None,
+    references: Seq[BaseUnit],
+    ordering: SpecOrdering,
+    renderOptions: RenderOptions,
+    registry: AMLRegistry)(implicit val nodeMappableFinder: NodeMappableFinder)
     extends EntryEmitter
     with AmlEmittersHelper {
   override def emit(b: YDocument.EntryBuilder): Unit = {
@@ -46,7 +50,8 @@ case class ExternalLinkEmitter(key: String,
                               ordering,
                               discriminator = None,
                               keyPropertyId = keyPropertyId,
-                              renderOptions = renderOptions
+                              renderOptions = renderOptions,
+                              registry = registry
                           ).emit(l)
                         case _ => // ignore, error
                       }
@@ -64,7 +69,7 @@ case class ExternalLinkEmitter(key: String,
     )
   }
 
-  protected def nodeMappingForObjectProperty(propertyMapping: PropertyMapping,
+  protected def nodeMappingForObjectProperty(propertyMapping: PropertyLikeMapping[_],
                                              dialectDomainElement: DialectDomainElement): Option[NodeMappable] = {
     // this can be multiple mappings if we have a union in the range or a range pointing to a union mapping
     val nodeMappings: Seq[NodeMapping] =

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/NodeFieldEmitters.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/NodeFieldEmitters.scala
@@ -2,7 +2,7 @@ package amf.aml.internal.render.emitters.instances
 
 import amf.aml.client.scala.model.document.Dialect
 import amf.aml.client.scala.model.domain._
-import amf.aml.internal.metamodel.domain.{NodeMappableModel, NodeWithDiscriminatorModel, PropertyLikeMappingModel}
+import amf.aml.internal.metamodel.domain.{NodeMappableModel, PropertyLikeMappingModel}
 import amf.aml.internal.registries.AMLRegistry
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.model.document.BaseUnit
@@ -13,6 +13,29 @@ import amf.core.internal.render.BaseEmitters.{ArrayEmitter, EntryPartEmitter, Va
 import amf.core.internal.render.SpecOrdering
 import amf.core.internal.render.emitters.EntryEmitter
 import org.mulesoft.common.time.SimpleDateTime
+
+object SemanticExtensionNodeEmitter {
+  def apply(node: DomainElement,
+            nodeMappable: NodeMappable[_ <: NodeMappableModel],
+            dialect: Dialect,
+            ordering: SpecOrdering,
+            renderOptions: RenderOptions,
+            registry: AMLRegistry,
+            keyOverride: String)(implicit finder: NodeMappableFinder): NodeFieldEmitters = {
+    NodeFieldEmitters(node,
+                      nodeMappable,
+                      dialect.references,
+                      dialect,
+                      ordering,
+                      None,
+                      None,
+                      emitDialect = false,
+                      topLevelEmitters = Nil,
+                      renderOptions,
+                      registry,
+                      Some(keyOverride))
+  }
+}
 
 case class NodeFieldEmitters(node: DomainElement,
                              nodeMappable: NodeMappable[_ <: NodeMappableModel],
@@ -28,160 +51,129 @@ case class NodeFieldEmitters(node: DomainElement,
                              keyOverride: Option[String] = None)(implicit val nodeMappableFinder: NodeMappableFinder)
     extends AmlEmittersHelper {
 
-  def emitField(field: Field): Seq[EntryEmitter] = {
-    findPropertyMapping(field) map { propertyMapping =>
-      if (keyPropertyId.isEmpty || propertyMapping
-            .nodePropertyMapping()
-            .value() != keyPropertyId.get) {
-
-        val key                    = keyOverride.getOrElse(propertyMapping.name().value())
-        val propertyClassification = propertyMapping.classification()
-
-        val nextEmitter: Seq[EntryEmitter] =
-          node.fields.getValueAsOption(field) match {
-            case Some(entry) if isScalar(entry) =>
-              val scalar = entry.value.asInstanceOf[AmfScalar]
-              emitScalar(key, field, scalar, Some(entry.annotations))
-
-            case Some(entry) if isArray(entry) && propertyClassification == LiteralPropertyCollection =>
-              val array = entry.value.asInstanceOf[AmfArray]
-              emitScalarArray(key, field, array, Some(entry.annotations))
-
-            case Some(entry)
-                if entry.value
-                  .isInstanceOf[DialectDomainElement] && propertyClassification == ExtensionPointProperty =>
-              val element = entry.value.asInstanceOf[DialectDomainElement]
-              emitExternalObject(key, element)
-
-            case Some(entry)
-                if entry.value
-                  .isInstanceOf[DialectDomainElement] && propertyClassification == ExternalLinkProperty =>
-              val element = entry.value.asInstanceOf[DialectDomainElement]
-              emitExternalLink(key, element, propertyMapping)
-
-            case Some(entry)
-                if entry.value
-                  .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && !propertyMapping.isUnion =>
-              val element = entry.value.asInstanceOf[DialectDomainElement]
-              val result  = emitObjectEntry(key, element, propertyMapping, Some(entry.annotations))
-              result
-
-            case Some(entry) if isArray(entry) && propertyClassification == ExternalLinkProperty =>
-              val array = entry.value.asInstanceOf[AmfArray]
-              emitExternalLink(key, array, propertyMapping, Some(entry.annotations))
-
-            case Some(entry)
-                if isArray(entry) && propertyClassification == ObjectPropertyCollection && !propertyMapping.isUnion =>
-              val array = entry.value.asInstanceOf[AmfArray]
-              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
-
-            case Some(entry) if isArray(entry) && propertyClassification == ObjectMapProperty =>
-              val array = entry.value.asInstanceOf[AmfArray]
-              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
-
-            case Some(entry)
-                if entry.value
-                  .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && propertyMapping.isUnion =>
-              val element = entry.value.asInstanceOf[DialectDomainElement]
-              emitObjectEntry(key, element, propertyMapping)
-
-            case Some(entry)
-                if isArray(entry) && propertyClassification == ObjectPropertyCollection && propertyMapping.isUnion =>
-              val array = entry.value.asInstanceOf[AmfArray]
-              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
-
-            case Some(entry)
-                if isArray(entry) && propertyClassification == ObjectPairProperty && propertyMapping
-                  .isInstanceOf[PropertyMapping] =>
-              val array = entry.value.asInstanceOf[AmfArray]
-              emitObjectPairs(key, array, propertyMapping.asInstanceOf[PropertyMapping], Some(entry.annotations))
-            case None => Nil // ignore
-          }
-        nextEmitter
-      } else Nil
+  def emitField(field: Field): Option[EntryEmitter] = {
+    findPropertyMapping(field).filter { mapping =>
+      keyPropertyId.isEmpty || mapping.nodePropertyMapping().value() != keyPropertyId.get
+    } flatMap { propertyMapping =>
+      val key                    = keyOverride.getOrElse(propertyMapping.name().value())
+      val propertyClassification = propertyMapping.classification()
+      node.fields
+        .getValueAsOption(field)
+        .map { value =>
+          emitterFor(field, propertyMapping, key, propertyClassification, value)
+        }
     }
-  }.getOrElse(Nil)
-
-  private def isArray(entry: Value) = {
-    entry.value
-      .isInstanceOf[AmfArray]
   }
 
-  private def isScalar(entry: Value) = {
-    entry.value.isInstanceOf[AmfScalar]
+  private def emitterFor(field: Field,
+                         propertyMapping: PropertyLikeMapping[_ <: PropertyLikeMappingModel],
+                         key: String,
+                         propertyClassification: PropertyClassification,
+                         value: Value) = {
+    (value.value, propertyClassification) match {
+      case (scalar: AmfScalar, _) => emitScalar(key, field, scalar, Some(value.annotations))
+
+      case (array: AmfArray, LiteralPropertyCollection) =>
+        emitScalarArray(key, field, array, Some(value.annotations))
+
+      case (element: DialectDomainElement, ExtensionPointProperty) => emitExternalObject(key, element)
+
+      case (element: DialectDomainElement, ExternalLinkProperty) =>
+        emitExternalLink(key, element, propertyMapping)
+
+      case (element: DialectDomainElement, ObjectProperty) if !propertyMapping.isUnion =>
+        emitObjectEntry(key, element, propertyMapping, Some(value.annotations))
+
+      case (array: AmfArray, ExternalLinkProperty) =>
+        emitExternalLink(key, array, propertyMapping, Some(value.annotations))
+
+      case (array: AmfArray, ObjectPropertyCollection) if !propertyMapping.isUnion =>
+        emitObjectEntry(key, array, propertyMapping, Some(value.annotations))
+
+      case (array: AmfArray, ObjectMapProperty) =>
+        emitObjectEntry(key, array, propertyMapping, Some(value.annotations))
+
+      case (element: DialectDomainElement, ObjectProperty) if propertyMapping.isUnion =>
+        emitObjectEntry(key, element, propertyMapping)
+
+      case (array: AmfArray, ObjectPropertyCollection) if propertyMapping.isUnion =>
+        emitObjectEntry(key, array, propertyMapping, Some(value.annotations))
+
+      case (array: AmfArray, ObjectPairProperty) if propertyMapping.isInstanceOf[PropertyMapping] =>
+        emitObjectPairs(key, array, propertyMapping.asInstanceOf[PropertyMapping], Some(value.annotations))
+    }
   }
 
   protected def emitExternalLink(key: String,
                                  target: AmfElement,
                                  propertyMapping: PropertyLikeMapping[_ <: PropertyLikeMappingModel],
-                                 annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
-    Seq(
-        ExternalLinkEmitter(key,
-                            dialect,
-                            target,
-                            propertyMapping,
-                            annotations,
-                            keyPropertyId,
-                            references,
-                            ordering,
-                            renderOptions,
-                            registry))
+                                 annotations: Option[Annotations] = None): EntryEmitter = {
+
+    ExternalLinkEmitter(key,
+                        dialect,
+                        target,
+                        propertyMapping,
+                        annotations,
+                        keyPropertyId,
+                        references,
+                        ordering,
+                        renderOptions,
+                        registry)
   }
 
   private def emitScalar(key: String,
                          field: Field,
                          scalar: AmfScalar,
-                         annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
+                         annotations: Option[Annotations] = None): EntryEmitter = {
     val formatted = scalar.value match {
       case date: SimpleDateTime => date.toString
       case other                => other
     }
 
-    Seq(ValueEmitter(key, FieldEntry(field, Value(AmfScalar(formatted), annotations.getOrElse(scalar.annotations)))))
+    ValueEmitter(key, FieldEntry(field, Value(AmfScalar(formatted), annotations.getOrElse(scalar.annotations))))
   }
 
   private def emitScalarArray(key: String,
                               field: Field,
                               array: AmfArray,
-                              annotations: Option[Annotations]): Seq[EntryEmitter] =
-    Seq(ArrayEmitter(key, FieldEntry(field, Value(array, annotations.getOrElse(array.annotations))), ordering))
+                              annotations: Option[Annotations]): EntryEmitter =
+    ArrayEmitter(key, FieldEntry(field, Value(array, annotations.getOrElse(array.annotations))), ordering)
 
   protected def emitObjectEntry(key: String,
                                 target: AmfElement,
                                 propertyMapping: PropertyLikeMapping[_ <: PropertyLikeMappingModel],
-                                annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
+                                annotations: Option[Annotations] = None): EntryEmitter = {
 
-    Seq(
-        DialectObjectEntryEmitter(key,
-                                  target,
-                                  propertyMapping,
-                                  references,
-                                  dialect,
-                                  ordering,
-                                  renderOptions,
-                                  annotations,
-                                  registry))
+    DialectObjectEntryEmitter(key,
+                              target,
+                              propertyMapping,
+                              references,
+                              dialect,
+                              ordering,
+                              renderOptions,
+                              annotations,
+                              registry)
   }
 
-  protected def emitExternalObject(key: String, element: DialectDomainElement): Seq[EntryEmitter] = {
+  protected def emitExternalObject(key: String, element: DialectDomainElement): EntryEmitter = {
     val (externalDialect, nextNodeMapping) = findNodeMappingById(element.definedBy.id)
-    Seq(
-        EntryPartEmitter(key,
-                         DialectNodeEmitter(element,
-                                            nextNodeMapping,
-                                            references,
-                                            externalDialect,
-                                            ordering,
-                                            emitDialect = true,
-                                            renderOptions = renderOptions,
-                                            registry = registry)))
+
+    EntryPartEmitter(key,
+                     DialectNodeEmitter(element,
+                                        nextNodeMapping,
+                                        references,
+                                        externalDialect,
+                                        ordering,
+                                        emitDialect = true,
+                                        renderOptions = renderOptions,
+                                        registry = registry))
   }
 
   private def emitObjectPairs(key: String,
                               array: AmfArray,
                               propertyMapping: PropertyMapping,
-                              annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
-    Seq(ObjectPairEmitter(key, array, propertyMapping, annotations))
+                              annotations: Option[Annotations] = None): EntryEmitter = {
+    ObjectPairEmitter(key, array, propertyMapping, annotations)
   }
 
   private def findPropertyMapping(field: Field): Option[PropertyLikeMapping[_ <: PropertyLikeMappingModel]] = {

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/NodeFieldEmitters.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/NodeFieldEmitters.scala
@@ -1,0 +1,222 @@
+package amf.aml.internal.render.emitters.instances
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.client.scala.model.domain._
+import amf.aml.internal.annotations.{CustomBase, CustomId}
+import amf.aml.internal.metamodel.domain.{DialectDomainElementModel, NodeMappableModel}
+import amf.core.client.common.position.Position
+import amf.core.client.common.position.Position.ZERO
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.model.document.BaseUnit
+import amf.core.client.scala.model.domain.{AmfArray, AmfElement, AmfScalar}
+import amf.core.internal.annotations.LexicalInformation
+import amf.core.internal.metamodel.Field
+import amf.core.internal.metamodel.domain.DomainElementModel
+import amf.core.internal.parser.domain.{Annotations, FieldEntry, Value}
+import amf.core.internal.render.BaseEmitters.{ArrayEmitter, EntryPartEmitter, ValueEmitter}
+import amf.core.internal.render.SpecOrdering
+import amf.core.internal.render.emitters.EntryEmitter
+import org.mulesoft.common.time.SimpleDateTime
+import org.yaml.model.YDocument.PartBuilder
+
+case class NodeFieldEmitters(node: DialectDomainElement,
+                             nodeMappable: NodeMappable[_ <: NodeMappableModel],
+                             references: Seq[BaseUnit],
+                             dialect: Dialect,
+                             ordering: SpecOrdering,
+                             keyPropertyId: Option[String] = None,
+                             discriminator: Option[(String, String)] = None,
+                             emitDialect: Boolean = false,
+                             topLevelEmitters: Seq[EntryEmitter] = Nil,
+                             renderOptions: RenderOptions)(implicit val nodeMappableFinder: NodeMappableFinder)
+    extends AmlEmittersHelper {
+
+  def emitField(field: Field): Seq[EntryEmitter] = {
+    findPropertyMapping(field) map { propertyMapping =>
+      if (keyPropertyId.isEmpty || propertyMapping
+            .nodePropertyMapping()
+            .value() != keyPropertyId.get) {
+
+        val key                    = propertyMapping.name().value()
+        val propertyClassification = propertyMapping.classification()
+
+        val nextEmitter: Seq[EntryEmitter] =
+          node.fields.getValueAsOption(field) match {
+            case Some(entry) if isScalar(entry) =>
+              val scalar = entry.value.asInstanceOf[AmfScalar]
+              emitScalar(key, field, scalar, Some(entry.annotations))
+
+            case Some(entry) if isArray(entry) && propertyClassification == LiteralPropertyCollection =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitScalarArray(key, field, array, Some(entry.annotations))
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ExtensionPointProperty =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              emitExternalObject(key, element, propertyMapping)
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ExternalLinkProperty =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              emitExternalLink(key, element, propertyMapping)
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && !propertyMapping.isUnion =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              val result  = emitObjectEntry(key, element, propertyMapping, Some(entry.annotations))
+              result
+
+            case Some(entry) if isArray(entry) && propertyClassification == ExternalLinkProperty =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitExternalLink(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry)
+                if isArray(entry) && propertyClassification == ObjectPropertyCollection && !propertyMapping.isUnion =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry) if isArray(entry) && propertyClassification == ObjectMapProperty =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry)
+                if entry.value
+                  .isInstanceOf[DialectDomainElement] && propertyClassification == ObjectProperty && propertyMapping.isUnion =>
+              val element = entry.value.asInstanceOf[DialectDomainElement]
+              emitObjectEntry(key, element, propertyMapping)
+
+            case Some(entry)
+                if isArray(entry) && propertyClassification == ObjectPropertyCollection && propertyMapping.isUnion =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectEntry(key, array, propertyMapping, Some(entry.annotations))
+
+            case Some(entry) if isArray(entry) && propertyClassification == ObjectPairProperty =>
+              val array = entry.value.asInstanceOf[AmfArray]
+              emitObjectPairs(key, array, propertyMapping, Some(entry.annotations))
+            case None => Nil // ignore
+          }
+        nextEmitter
+      } else Nil
+    }
+  }.getOrElse(Nil)
+
+  private def isArray(entry: Value) = {
+    entry.value
+      .isInstanceOf[AmfArray]
+  }
+
+  private def isScalar(entry: Value) = {
+    entry.value.isInstanceOf[AmfScalar]
+  }
+
+  protected def emitExternalLink(key: String,
+                                 target: AmfElement,
+                                 propertyMapping: PropertyMapping,
+                                 annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
+    Seq(
+        ExternalLinkEmitter(key,
+                            dialect,
+                            target,
+                            propertyMapping,
+                            annotations,
+                            keyPropertyId,
+                            references,
+                            ordering,
+                            renderOptions))
+  }
+
+  private def nodeMappingForObjectProperty(propertyMapping: PropertyMapping,
+                                           dialectDomainElement: DialectDomainElement): Option[NodeMappable] = {
+    // this can be multiple mappings if we have a union in the range or a range pointing to a union mapping
+    val nodeMappings: Seq[NodeMapping] =
+      propertyMapping.objectRange().flatMap { rangeNodeMapping =>
+        findAllNodeMappings(rangeNodeMapping.value())
+      }
+    nodeMappings.find(
+        nodeMapping =>
+          dialectDomainElement.meta.`type`
+            .map(_.iri())
+            .exists(i => i == nodeMapping.nodetypeMapping.value() || i == nodeMapping.id))
+  }
+
+  private def emitScalar(key: String,
+                         field: Field,
+                         scalar: AmfScalar,
+                         annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
+    val formatted = scalar.value match {
+      case date: SimpleDateTime => date.toString
+      case other                => other
+    }
+
+    Seq(ValueEmitter(key, FieldEntry(field, Value(AmfScalar(formatted), annotations.getOrElse(scalar.annotations)))))
+  }
+
+  private def emitScalarArray(key: String,
+                              field: Field,
+                              array: AmfArray,
+                              annotations: Option[Annotations]): Seq[EntryEmitter] =
+    Seq(ArrayEmitter(key, FieldEntry(field, Value(array, annotations.getOrElse(array.annotations))), ordering))
+
+  protected def emitObjectEntry(key: String,
+                                target: AmfElement,
+                                propertyMapping: PropertyMapping,
+                                annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
+
+    Seq(
+        DialectObjectEntryEmitter(key,
+                                  target,
+                                  propertyMapping,
+                                  references,
+                                  dialect,
+                                  ordering,
+                                  renderOptions,
+                                  annotations))
+  }
+
+  protected def emitExternalObject(key: String,
+                                   element: DialectDomainElement,
+                                   propertyMapping: PropertyMapping): Seq[EntryEmitter] = {
+    val (externalDialect, nextNodeMapping) = findNodeMappingById(element.definedBy.id)
+    Seq(
+        EntryPartEmitter(key,
+                         DialectNodeEmitter(element,
+                                            nextNodeMapping,
+                                            references,
+                                            externalDialect,
+                                            ordering,
+                                            emitDialect = true,
+                                            renderOptions = renderOptions)))
+  }
+
+  private def emitObjectPairs(key: String,
+                              array: AmfArray,
+                              propertyMapping: PropertyMapping,
+                              annotations: Option[Annotations] = None): Seq[EntryEmitter] = {
+    Seq(ObjectPairEmitter(key, array, propertyMapping, annotations))
+  }
+
+  private def findPropertyMapping(field: Field): Option[PropertyMapping] = {
+    val iri = field.value.iri()
+    nodeMappable match {
+      case nodeMapping: NodeMapping =>
+        nodeMapping
+          .propertiesMapping()
+          .find(_.nodePropertyMapping().value() == iri)
+      case unionMapping: UnionNodeMapping =>
+        val rangeIds: Seq[String] = unionMapping.objectRange().map(_.value())
+        val nodeMappingsInRange = rangeIds.map { id: String =>
+          findNodeMappingById(id) match {
+            case (_, nodeMapping: NodeMapping) => Some(nodeMapping)
+            case _                             => None
+          }
+        } collect { case Some(nodeMapping: NodeMapping) => nodeMapping }
+        // we need to do this because the same property (with different ranges) might be defined in multiple node mappings
+        //        val nodeMetaTypes = node.meta.typeIri.map(_ -> true).toMap
+        //        nodeMappingsInRange = nodeMappingsInRange.filter { nodeMapping => nodeMetaTypes.contains(nodeMapping.id) }
+        nodeMappingsInRange.flatMap(_.propertiesMapping()).find(_.nodePropertyMapping().value() == iri)
+    }
+  }
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/ObjectPairEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/instances/ObjectPairEmitter.scala
@@ -1,0 +1,68 @@
+package amf.aml.internal.render.emitters.instances
+
+import amf.aml.client.scala.model.domain.{DialectDomainElement, PropertyMapping}
+import amf.core.client.common.position.Position
+import amf.core.client.common.position.Position.ZERO
+import amf.core.client.scala.model.domain.{AmfArray, AmfElement, AmfScalar}
+import amf.core.internal.annotations.LexicalInformation
+import amf.core.internal.parser.domain.Annotations
+import amf.core.internal.render.BaseEmitters.MapEntryEmitter
+import amf.core.internal.render.emitters.EntryEmitter
+import org.yaml.model.YDocument
+
+case class ObjectPairEmitter(key: String,
+                             array: AmfArray,
+                             propertyMapping: PropertyMapping,
+                             annotations: Option[Annotations] = None)
+    extends EntryEmitter {
+  override def emit(b: YDocument.EntryBuilder): Unit = {
+    val keyProperty   = propertyMapping.mapTermKeyProperty().value()
+    val valueProperty = propertyMapping.mapTermValueProperty().value()
+    b.entry(
+        key,
+        _.obj { b =>
+          val sortedElements = array.values.sortBy(elementPosition)
+          sortedElements.foreach {
+            case element: DialectDomainElement =>
+              val keyField   = findFieldWithIri(keyProperty, element)
+              val valueField = findFieldWithIri(valueProperty, element)
+              if (keyField.isDefined && valueField.isDefined) {
+                val keyLiteral =
+                  element.fields.getValueAsOption(keyField.get).map(_.value)
+                val valueLiteral = element.fields
+                  .getValueAsOption(valueField.get)
+                  .map(_.value)
+                (keyLiteral, valueLiteral) match {
+                  case (Some(keyScalar: AmfScalar), Some(valueScalar: AmfScalar)) =>
+                    MapEntryEmitter(keyScalar.value.toString, valueScalar.value.toString).emit(b)
+                  case _ =>
+                    throw new Exception("Cannot generate object pair without scalar values for key and value")
+                }
+              } else {
+                throw new Exception("Cannot generate object pair with undefined key or value")
+              }
+            case _ => // ignore
+          }
+        }
+    )
+  }
+
+  private def findFieldWithIri(keyProperty: String, element: DialectDomainElement) = {
+    element.meta.fields.find(_.value.iri() == keyProperty)
+  }
+
+  private def elementPosition(elem: AmfElement) = {
+    elem.annotations
+      .find(classOf[LexicalInformation])
+      .map(_.range.start)
+      .getOrElse(ZERO)
+  }
+
+  override def position(): Position = {
+    annotations
+      .flatMap(_.find(classOf[LexicalInformation]))
+      .orElse(array.annotations.find(classOf[LexicalInformation]))
+      .map(_.range.start)
+      .getOrElse(ZERO)
+  }
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectInstanceRenderingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectInstanceRenderingPlugin.scala
@@ -2,6 +2,7 @@ package amf.aml.internal.render.plugin
 
 import amf.aml.client.scala.model.document.{Dialect, DialectInstanceUnit}
 import amf.aml.internal.AMLDialectInstancePlugin
+import amf.aml.internal.registries.AMLRegistry
 import amf.aml.internal.render.emitters.instances.{DefaultNodeMappableFinder, DialectInstancesEmitter}
 import amf.core.client.common.{NormalPriority, PluginPriority}
 import amf.core.client.scala.config.RenderOptions
@@ -43,7 +44,9 @@ class AMLDialectInstanceRenderingPlugin(val dialect: Dialect)
     val finder = DefaultNodeMappableFinder(dialects)
     unit match {
       case instance: DialectInstanceUnit =>
-        Some(DialectInstancesEmitter(instance, dialect, config.renderOptions)(finder).emitInstance())
+        Some(
+            DialectInstancesEmitter(instance, dialect, config.renderOptions, AMLRegistry(config.registry, dialects))(
+                finder).emitInstance())
       case _ => None
     }
   }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectInstanceRenderingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectInstanceRenderingPlugin.scala
@@ -65,7 +65,7 @@ class AMLDialectInstanceRenderingPlugin(val dialect: Dialect)
     Seq(`application/yaml`, `application/json`)
 
   override protected def unparseAsYDocument(unit: BaseUnit,
-                                            renderOptions: RenderOptions,
+                                            renderConfig: RenderConfiguration,
                                             errorHandler: AMFErrorHandler): Option[YDocument] =
     throw new UnsupportedOperationException("Unreachable code")
 }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectRenderingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLDialectRenderingPlugin.scala
@@ -61,7 +61,7 @@ class AMLDialectRenderingPlugin extends SYAMLBasedRenderPlugin {
   override def mediaTypes: Seq[String] = Seq(`application/yaml`)
 
   override protected def unparseAsYDocument(unit: BaseUnit,
-                                            renderOptions: RenderOptions,
+                                            renderConfig: RenderConfiguration,
                                             errorHandler: AMFErrorHandler): Option[YDocument] =
     throw new UnsupportedOperationException("Unreachable code")
 }

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLVocabularyRenderingPlugin.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/plugin/AMLVocabularyRenderingPlugin.scala
@@ -6,7 +6,7 @@ import amf.core.client.common.{NormalPriority, PluginPriority}
 import amf.core.client.scala.config.RenderOptions
 import amf.core.client.scala.errorhandling.AMFErrorHandler
 import amf.core.client.scala.model.document.BaseUnit
-import amf.core.internal.plugins.render.{RenderInfo, SYAMLBasedRenderPlugin}
+import amf.core.internal.plugins.render.{RenderConfiguration, RenderInfo, SYAMLBasedRenderPlugin}
 import amf.core.internal.remote.Mimes._
 import org.yaml.model.YDocument
 
@@ -23,7 +23,7 @@ class AMLVocabularyRenderingPlugin extends SYAMLBasedRenderPlugin {
   override def mediaTypes: Seq[String] = Seq(`application/yaml`)
 
   override protected def unparseAsYDocument(unit: BaseUnit,
-                                            renderOptions: RenderOptions,
+                                            renderConfig: RenderConfiguration,
                                             errorHandler: AMFErrorHandler): Option[YDocument] = {
     unit match {
       case vocabulary: Vocabulary => Some(VocabularyEmitter(vocabulary).emitVocabulary())

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/ExtensionDialectFinder.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/ExtensionDialectFinder.scala
@@ -1,0 +1,18 @@
+package amf.aml.internal.semantic
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.internal.registries.AMLRegistry
+import org.mulesoft.common.core.CachedFunction
+import org.mulesoft.common.functional.MonadInstances.optionMonad
+
+trait ExtensionDialectFinder {
+  def find(name: String): Option[Dialect]
+}
+
+case class CachedExtensionDialectFinder(registry: AMLRegistry) extends ExtensionDialectFinder {
+
+  private val findExtensionDialect = CachedFunction.fromMonadic { name =>
+    registry.findExtension(name)
+  }
+  override def find(name: String): Option[Dialect] = findExtensionDialect.runCached(name)
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionOps.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionOps.scala
@@ -1,0 +1,21 @@
+package amf.aml.internal.semantic
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.client.scala.model.domain.AnnotationMapping
+import amf.aml.internal.semantic.SemanticExtensionHelper.{findAnnotationMapping, findSemanticExtension}
+
+object SemanticExtensionOps {
+
+  def findExtensionMapping(name: String,
+                           parentTypes: Seq[String],
+                           finder: ExtensionDialectFinder): Option[(AnnotationMapping, Dialect)] = {
+    findExtensionDialect(name, finder).flatMap { dialect =>
+      findSemanticExtension(dialect, name)
+        .map(findAnnotationMapping(dialect, _))
+        .filter(_.appliesTo(parentTypes))
+        .map(mapping => (mapping, dialect))
+    }
+  }
+
+  private def findExtensionDialect(name: String, finder: ExtensionDialectFinder): Option[Dialect] = finder.find(name)
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionParser.scala
@@ -1,0 +1,87 @@
+package amf.aml.internal.semantic
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.client.scala.model.domain.{AnnotationMapping, DialectDomainElement}
+import amf.aml.internal.parse.instances.DialectInstanceContext
+import amf.aml.internal.parse.instances.parser.{ElementPropertyParser, InstanceNodeParser}
+import amf.aml.internal.render.emitters.instances.DefaultNodeMappableFinder
+import amf.aml.internal.semantic.SemanticExtensionHelper.{findAnnotationMapping, findSemanticExtension}
+import amf.aml.internal.semantic.SemanticExtensionOps.findExtensionMapping
+import amf.core.client.scala.model.domain.extensions.{CustomDomainProperty, DomainExtension}
+import amf.core.client.scala.parse.document.{
+  EmptyFutureDeclarations,
+  ParserContext,
+  SyamlParsedDocument,
+  UnspecifiedReference
+}
+import amf.core.internal.parser.Root
+import amf.core.internal.parser.domain.Annotations
+import org.yaml.model.{YDocument, YMap, YMapEntry, YNode}
+
+class SemanticExtensionParser(finder: ExtensionDialectFinder) {
+
+  def parse(extensionName: String,
+            parentTypes: Seq[String],
+            ast: YMapEntry,
+            ctx: ParserContext,
+            extensionId: String): Option[DomainExtension] = {
+    findExtensionMapping(extensionName, parentTypes, finder).map {
+      case (mapping, dialect) => parseSemanticExtension(dialect, mapping, ast, ctx, extensionId, extensionName)
+    }
+  }
+
+  private def parseSemanticExtension(dialect: Dialect,
+                                     mapping: AnnotationMapping,
+                                     ast: YMapEntry,
+                                     ctx: ParserContext,
+                                     extensionId: String,
+                                     extensionName: String): DomainExtension = {
+
+    implicit val instanceCtx: DialectInstanceContext = instanceContext(dialect, ctx)
+
+    val value = ast.value
+
+    val instanceElement: DialectDomainElement = parseAnnotation(mapping, ast, extensionId)
+
+    val property                   = createCustomDomainProperty(instanceElement, extensionName, value)
+    val extension: DomainExtension = createDomainExtension(extensionName, value, extensionId, property)
+    mergeAnnotationIntoExtension(instanceElement, extension)
+  }
+
+  private def instanceContext(dialect: Dialect, ctx: ParserContext) = {
+    val nextCtx = ctx.copy(futureDeclarations = EmptyFutureDeclarations())
+    new DialectInstanceContext(dialect, DefaultNodeMappableFinder(Seq(dialect)), nextCtx)
+  }
+
+  private def mergeAnnotationIntoExtension(instanceElement: DialectDomainElement, extension: DomainExtension) = {
+    val fields = instanceElement.fields.fields()
+    fields.foldLeft(extension) { (acc, curr) =>
+      acc.set(curr.field, curr.element, curr.value.annotations)
+    }
+  }
+
+  private def createDomainExtension(key: String, value: YNode, id: String, property: CustomDomainProperty) = {
+    val extension = DomainExtension()
+      .withId(id)
+      .withDefinedBy(property)
+      .withName(key)
+      .add(Annotations(value))
+    extension
+  }
+
+  private def createCustomDomainProperty(instanceElement: DialectDomainElement, key: String, value: YNode) = {
+    CustomDomainProperty(Annotations(value)).withId(instanceElement.id).withName(key, Annotations())
+  }
+
+  private def parseAnnotation(mapping: AnnotationMapping, ast: YMapEntry, extensionId: String)(
+      implicit ctx: DialectInstanceContext) = {
+    // TODO: improve, shouldn't have to create fake root node
+    val fakeRoot        = Root(SyamlParsedDocument(YDocument(YMap.empty)), "", "", Seq.empty, UnspecifiedReference, "{}")
+    val instanceElement = DialectDomainElement().withId("someId")
+    val nodeParser      = InstanceNodeParser(fakeRoot)
+    val propertyParser  = new ElementPropertyParser(fakeRoot, YMap.empty, nodeParser.parse)
+    propertyParser.parse(extensionId, ast, mapping, instanceElement)
+    ctx.futureDeclarations.resolve()
+    instanceElement
+  }
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionRenderer.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionRenderer.scala
@@ -1,0 +1,39 @@
+package amf.aml.internal.semantic
+
+import amf.aml.client.scala.model.document.Dialect
+import amf.aml.client.scala.model.domain.AnnotationMapping
+import amf.aml.internal.registries.AMLRegistry
+import amf.aml.internal.render.emitters.instances.{
+  DefaultNodeMappableFinder,
+  NodeMappableFinder,
+  SemanticExtensionNodeEmitter
+}
+import amf.aml.internal.semantic.SemanticExtensionOps.findExtensionMapping
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.model.domain.extensions.DomainExtension
+import amf.core.internal.render.SpecOrdering
+import amf.core.internal.render.emitters.EntryEmitter
+
+class SemanticExtensionRenderer(finder: ExtensionDialectFinder, registry: AMLRegistry) {
+
+  def render(key: String,
+             extension: DomainExtension,
+             parentTypes: Seq[String],
+             ordering: SpecOrdering,
+             renderOptions: RenderOptions): Option[EntryEmitter] = {
+    findMappingThatDefinesExtension(extension, parentTypes)
+      .flatMap {
+        case (mapping, dialect) =>
+          val finder = DefaultNodeMappableFinder(dialect)
+          SemanticExtensionNodeEmitter(extension, mapping, dialect, ordering, renderOptions, registry, key)(finder)
+            .emitField(mapping.toField())
+      }
+  }
+
+  private def findMappingThatDefinesExtension(extension: DomainExtension,
+                                              parentTypes: Seq[String]): Option[(AnnotationMapping, Dialect)] = {
+    val maybeName = Option(extension.definedBy).flatMap(_.name.option())
+    maybeName
+      .flatMap(name => findExtensionMapping(name, parentTypes, finder))
+  }
+}

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionsFacade.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/semantic/SemanticExtensionsFacade.scala
@@ -1,157 +1,48 @@
 package amf.aml.internal.semantic
 
-import amf.aml.client.scala.model.document.Dialect
-import amf.aml.client.scala.model.domain.{AnnotationMapping, DialectDomainElement}
-import amf.aml.internal.parse.instances.DialectInstanceContext
-import amf.aml.internal.parse.instances.parser.{ElementPropertyParser, InstanceNodeParser}
 import amf.aml.internal.registries.AMLRegistry
-import amf.aml.internal.render.emitters.instances.{
-  DefaultNodeMappableFinder,
-  DialectNodeEmitter,
-  NodeFieldEmitters,
-  NodeMappableFinder
-}
-import amf.aml.internal.semantic.SemanticExtensionHelper.{findAnnotationMapping, findSemanticExtension}
+import amf.aml.internal.render.emitters.instances.{NodeFieldEmitters, NodeMappableFinder}
 import amf.core.client.scala.config.RenderOptions
-import amf.core.client.scala.model.domain.extensions.{CustomDomainProperty, DomainExtension}
-import amf.core.client.scala.parse.document.{
-  EmptyFutureDeclarations,
-  ParserContext,
-  SyamlParsedDocument,
-  UnspecifiedReference
-}
-import amf.core.internal.parser.domain.Annotations
-import amf.core.internal.parser.{ParseConfiguration, Root}
+import amf.core.client.scala.model.domain.extensions.DomainExtension
+import amf.core.client.scala.parse.document.ParserContext
+import amf.core.internal.parser.ParseConfiguration
+import amf.core.internal.plugins.render.RenderConfiguration
 import amf.core.internal.render.SpecOrdering
-import org.mulesoft.common.core.CachedFunction
-import org.mulesoft.common.functional.MonadInstances._
-import org.yaml.model.YDocument.PartBuilder
-import org.yaml.model.{YDocument, YMap, YMapEntry, YNode}
+import org.yaml.model.YMapEntry
 
 class SemanticExtensionsFacade private (val registry: AMLRegistry) {
+
+  private val finder   = CachedExtensionDialectFinder(registry)
+  private val parser   = new SemanticExtensionParser(finder)
+  private val renderer = new SemanticExtensionRenderer(finder, registry)
 
   def parse(extensionName: String,
             parentTypes: Seq[String],
             ast: YMapEntry,
             ctx: ParserContext,
             extensionId: String): Option[DomainExtension] = {
-    findExtensionMapping(extensionName, parentTypes).map {
-      case (mapping, dialect) => parseSemanticExtension(dialect, mapping, ast, ctx, extensionId, extensionName)
-    }
+    parser.parse(extensionName, parentTypes, ast, ctx, extensionId)
   }
 
   def render(key: String,
              extension: DomainExtension,
              parentTypes: Seq[String],
              ordering: SpecOrdering,
-             renderOptions: RenderOptions,
-             nodeMappableFinder: NodeMappableFinder) = {
-    val maybeName = Option(extension.definedBy).flatMap(_.name.option())
-    maybeName
-      .flatMap(name => findExtensionMapping(name, parentTypes))
-      .map {
-        case (mapping, dialect) =>
-          NodeFieldEmitters(extension,
-                            mapping,
-                            dialect.references,
-                            dialect,
-                            ordering,
-                            None,
-                            None,
-                            false,
-                            Nil,
-                            renderOptions,
-                            registry,
-                            Some(key))(nodeMappableFinder).emitField(mapping.toField())
-      }
-      .getOrElse(Nil)
-  }
-
-  private def findExtensionMapping(name: String, parentTypes: Seq[String]): Option[(AnnotationMapping, Dialect)] = {
-    findExtensionDialect(name).flatMap { dialect =>
-      findSemanticExtension(dialect, name)
-        .map(findAnnotationMapping(dialect, _))
-        .filter(_.appliesTo(parentTypes))
-        .map(mapping => (mapping, dialect))
-    }
-  }
-
-  def findAnnotation(extensionName: String): Option[AnnotationMapping] = {
-    findExtensionDialect(extensionName).flatMap { dialect =>
-      findSemanticExtension(dialect, extensionName).map(findAnnotationMapping(dialect, _))
-    }
-  }
-
-  def findAnnotationMappingByExtension(extensionName: String, dialect: Dialect): Option[AnnotationMapping] =
-    findSemanticExtension(dialect, extensionName).map { extension =>
-      findAnnotationMapping(dialect, extension)
-    }
-
-  def findExtensionDialect(name: String): Option[Dialect] = findExtensionDialect.runCached(name)
-
-  def parseSemanticExtension(dialect: Dialect,
-                             mapping: AnnotationMapping,
-                             ast: YMapEntry,
-                             ctx: ParserContext,
-                             extensionId: String,
-                             extensionName: String): DomainExtension = {
-
-    implicit val instanceCtx: DialectInstanceContext = instanceContext(dialect, ctx)
-
-    val value = ast.value
-
-    val instanceElement: DialectDomainElement = parseAnnotation(mapping, ast, extensionId)
-
-    val property                   = createCustomDomainProperty(instanceElement, extensionName, value)
-    val extension: DomainExtension = createDomainExtension(extensionName, value, extensionId, property)
-    mergeAnnotationIntoExtension(instanceElement, extension)
-  }
-
-  private def instanceContext(dialect: Dialect, ctx: ParserContext) = {
-    val nextCtx = ctx.copy(futureDeclarations = EmptyFutureDeclarations())
-    new DialectInstanceContext(dialect, DefaultNodeMappableFinder(Seq(dialect)), nextCtx)
-  }
-
-  private def mergeAnnotationIntoExtension(instanceElement: DialectDomainElement, extension: DomainExtension) = {
-    val fields = instanceElement.fields.fields()
-    fields.foldLeft(extension) { (acc, curr) =>
-      acc.set(curr.field, curr.element, curr.value.annotations)
-    }
-  }
-
-  private def createDomainExtension(key: String, value: YNode, id: String, property: CustomDomainProperty) = {
-    val extension = DomainExtension()
-      .withId(id)
-      .withDefinedBy(property)
-      .withName(key)
-      .add(Annotations(value))
-    extension
-  }
-
-  private def createCustomDomainProperty(instanceElement: DialectDomainElement, key: String, value: YNode) = {
-    CustomDomainProperty(Annotations(value)).withId(instanceElement.id).withName(key, Annotations())
-  }
-
-  private def parseAnnotation(mapping: AnnotationMapping, ast: YMapEntry, extensionId: String)(
-      implicit ctx: DialectInstanceContext) = {
-    // TODO: improve, shouldn't have to create fake root node
-    val fakeRoot        = Root(SyamlParsedDocument(YDocument(YMap.empty)), "", "", Seq.empty, UnspecifiedReference, "{}")
-    val instanceElement = DialectDomainElement().withId("someId")
-    val nodeParser      = InstanceNodeParser(fakeRoot)
-    val propertyParser  = new ElementPropertyParser(fakeRoot, YMap.empty, nodeParser.parse)
-    propertyParser.parse(extensionId, ast, mapping, instanceElement)
-    ctx.futureDeclarations.resolve()
-    instanceElement
-  }
-
-  private val findExtensionDialect = CachedFunction.fromMonadic { name =>
-    registry.findExtension(name)
+             renderOptions: RenderOptions) = {
+    renderer.render(key, extension, parentTypes, ordering, renderOptions)
   }
 }
 
 object SemanticExtensionsFacade {
   def apply(registry: AMLRegistry): SemanticExtensionsFacade = new SemanticExtensionsFacade(registry)
-  // This method will assume that the parse configuration contains an AMLRegistry
-  def apply(config: ParseConfiguration): SemanticExtensionsFacade =
-    apply(config.registryContext.getRegistry.asInstanceOf[AMLRegistry])
+
+  def apply(config: ParseConfiguration): SemanticExtensionsFacade = config.registryContext.getRegistry match {
+    case registry: AMLRegistry => SemanticExtensionsFacade(registry)
+    case other                 => SemanticExtensionsFacade(AMLRegistry(other))
+  }
+
+  def apply(config: RenderConfiguration): SemanticExtensionsFacade = config.registry match {
+    case registry: AMLRegistry => SemanticExtensionsFacade(registry)
+    case other                 => SemanticExtensionsFacade(AMLRegistry(other))
+  }
 }

--- a/amf-aml/shared/src/test/resources/vocabularies2/semantic/instance.cycled.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/semantic/instance.cycled.yaml
@@ -1,0 +1,10 @@
+#%Github Repository 1.0
+name: MyRepo
+(maintainer):
+  users:
+    -
+      username: tomsfernandez
+      contributor: true
+    -
+      username: looseale
+      contributor: false

--- a/amf-aml/shared/src/test/scala/amf/testing/semantic/CycledSemanticRenderTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/semantic/CycledSemanticRenderTest.scala
@@ -1,0 +1,33 @@
+package amf.testing.semantic
+
+import amf.aml.client.scala.AMLConfiguration
+import amf.core.client.scala.config.RenderOptions
+import amf.core.client.scala.errorhandling.UnhandledErrorHandler
+import amf.core.internal.remote.Syntax.Yaml
+import amf.testing.common.cycling.FunSuiteCycleTests
+
+import scala.concurrent.Future
+
+class CycledSemanticRenderTest extends FunSuiteCycleTests {
+  override def basePath: String = "amf-aml/shared/src/test/resources/vocabularies2/semantic/"
+
+  test("Render object extension") {
+    getConfig("dialect-extensions.yaml").flatMap { config =>
+      cycle("instance.yaml", "instance.cycled.yaml", Some(Yaml), amlConfig = config)
+    }
+  }
+
+  test("Render scalar extension") {
+    getConfig("dialect-scalar-extensions.yaml").flatMap { config =>
+      cycle("instance-scalar.yaml", "instance-scalar.yaml", Some(Yaml), amlConfig = config)
+    }
+  }
+
+  private def getConfig(dialect: String): Future[AMLConfiguration] = {
+    AMLConfiguration
+      .predefined()
+      .withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris)
+      .withErrorHandlerProvider(() => UnhandledErrorHandler)
+      .withDialect(s"file://$basePath" + dialect)
+  }
+}


### PR DESCRIPTION
- Refactor: extracted some methods n1
- Refactor: extracted some methods n2
- Refactor: extracted some methods n3
- Refactor: extracted some methods n4
- Refactor: extracted some methods n5
- Refactor: extracted some methods n6
- Refactor: extracted some methods n7
- APIMF-3581: implemented SemEx render for un-transformed dialect instances
- APIMF-3581: big commit with several things: breakup of SemanticExtensionFacade, modifications for SemEx render integration in amf-api-contract

Related to: https://github.com/aml-org/amf-core/pull/399
