### PR TITLE
W-10803434: added 'additionalProperties' node mapping facet to avoid closed shape validation in instances

### DIFF
--- a/amf-aml/shared/src/main/scala/amf/aml/client/platform/model/domain/NodeMapping.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/platform/model/domain/NodeMapping.scala
@@ -3,7 +3,9 @@ package amf.aml.client.platform.model.domain
 import amf.aml.internal.convert.VocabulariesClientConverter._
 import amf.core.client.platform.model.domain.{DomainElement, Linkable}
 import amf.aml.client.scala.model.domain.{NodeMapping => InternalNodeMapping}
+import amf.aml.internal.metamodel.domain.NodeMappingModel.Closed
 import amf.core.client.platform.model.StrField
+import amf.core.client.scala.model.BoolField
 
 import scala.scalajs.js.annotation.{JSExportAll, JSExportTopLevel}
 
@@ -18,6 +20,7 @@ case class NodeMapping(override private[amf] val _internal: InternalNodeMapping)
   def propertiesMapping(): ClientList[PropertyMapping] = _internal.propertiesMapping().asClient
   def idTemplate: StrField                             = _internal.idTemplate
   def mergePolicy: StrField                            = _internal.mergePolicy
+  def closed: BoolField                                = _internal.closed
 
   def withName(name: String): NodeMapping = {
     _internal.withName(name)

--- a/amf-aml/shared/src/main/scala/amf/aml/client/scala/model/domain/NodeMapping.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/client/scala/model/domain/NodeMapping.scala
@@ -1,6 +1,6 @@
 package amf.aml.client.scala.model.domain
 
-import amf.core.client.scala.model.StrField
+import amf.core.client.scala.model.{BoolField, StrField}
 import amf.core.client.scala.model.domain.{DataNode, DomainElement, Linkable}
 import amf.core.internal.parser.domain.{Annotations, Fields}
 import amf.core.internal.utils._
@@ -20,10 +20,12 @@ class NodeMapping(override val fields: Fields, override val annotations: Annotat
   def nodetypeMapping: StrField                 = fields.field(NodeTypeMapping)
   def propertiesMapping(): Seq[PropertyMapping] = fields.field(PropertiesMapping)
   def idTemplate: StrField                      = fields.field(IdTemplate)
+  def closed: BoolField                         = fields.field(Closed)
   def resolvedExtends: Seq[String]              = fields.field(ResolvedExtends)
 
   def withNodeTypeMapping(nodeType: String): NodeMapping              = set(NodeTypeMapping, nodeType)
   def withPropertiesMapping(props: Seq[PropertyMapping]): NodeMapping = setArrayWithoutId(PropertiesMapping, props)
+  def withClosed(value: Boolean): NodeMapping                         = set(Closed, value)
   def withIdTemplate(idTemplate: String): NodeMapping                 = set(IdTemplate, idTemplate)
   def withResolvedExtends(ids: Seq[String]): NodeMapping              = set(ResolvedExtends, ids)
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/metamodel/domain/NodeMappingModel.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/metamodel/domain/NodeMappingModel.scala
@@ -3,6 +3,7 @@ package amf.aml.internal.metamodel.domain
 import amf.core.internal.metamodel.Field
 import amf.core.internal.metamodel.Type.{Array, Iri, Str}
 import amf.core.internal.metamodel.domain.{
+  ClosedModel,
   DomainElementModel,
   ExternalModelVocabularies,
   LinkableElementModel,
@@ -18,7 +19,8 @@ object NodeMappingModel
     extends DomainElementModel
     with LinkableElementModel
     with MergeableMappingModel
-    with NodeMappableModel {
+    with NodeMappableModel
+    with ClosedModel {
 
   val NodeTypeMapping: Field = Field(
       Iri,
@@ -42,7 +44,7 @@ object NodeMappingModel
   val ResolvedExtends: Field = Field(Array(Iri), Namespace.Meta + "resolvedExtends")
 
   override def fields: List[Field] =
-    NodeTypeMapping :: Name :: PropertiesMapping :: IdTemplate :: MergePolicy :: ResolvedExtends :: LinkableElementModel.fields ++ DomainElementModel.fields
+    NodeTypeMapping :: Name :: PropertiesMapping :: IdTemplate :: MergePolicy :: ResolvedExtends :: Closed :: LinkableElementModel.fields ++ DomainElementModel.fields
 
   override def modelInstance: AmfObject = NodeMapping()
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/dialects/DialectSyntax.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/dialects/DialectSyntax.scala
@@ -29,14 +29,15 @@ trait DialectSyntax { this: DialectContext =>
   )
 
   val nodeMapping: Map[String, Required] = Map(
-      "classTerm"   -> false,
-      "mapping"     -> false,
-      "idProperty"  -> false,
-      "idTemplate"  -> false,
-      "patch"       -> false,
-      "extends"     -> false,
-      "union"       -> false,
-      "conditional" -> false
+      "classTerm"            -> false,
+      "mapping"              -> false,
+      "idProperty"           -> false,
+      "idTemplate"           -> false,
+      "patch"                -> false,
+      "extends"              -> false,
+      "union"                -> false,
+      "conditional"          -> false,
+      "additionalProperties" -> false
   )
 
   val propertyLikeMapping: Map[String, Required] = Map(

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/dialects/nodemapping/like/NodeMappingParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/dialects/nodemapping/like/NodeMappingParser.scala
@@ -8,7 +8,7 @@ import amf.aml.internal.parse.dialects.property.like.PropertyLikeMappingParser
 import amf.aml.internal.parse.instances.BaseDirective
 import amf.aml.internal.validate.DialectValidations
 import amf.aml.internal.validate.DialectValidations.{DialectError, VariablesDefinedInBase}
-import amf.core.client.scala.model.domain.DomainElement
+import amf.core.client.scala.model.domain.{AmfScalar, DomainElement}
 import amf.core.client.scala.vocabulary.Namespace
 import amf.core.internal.datanode.DataNodeParser
 import amf.core.internal.metamodel.domain.ShapeModel
@@ -54,6 +54,15 @@ class NodeMappingParser(implicit ctx: DialectContext) extends NodeMappingLikePar
                                s"Cannot find class term with alias $classTermId",
                                entry.value.location)
           }
+        }
+    )
+
+    map.key(
+        "additionalProperties",
+        entry => {
+          val value   = entry.value.as[Boolean]
+          val negated = !value
+          nodeMapping.set(NodeMappingModel.Closed, AmfScalar(negated, Annotations.inferred()), Annotations(entry))
         }
     )
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/parse/instances/parser/InstanceNodeParser.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/parse/instances/parser/InstanceNodeParser.scala
@@ -142,7 +142,8 @@ case class InstanceNodeParser(root: Root)(implicit ctx: DialectInstanceContext) 
         case None => // ignore
       }
     }
-    checkNodeForAdditionalKeys(finalId, mapping.id, astMap.map, mapping, astMap, rootNode, additionalKey)
+    val shouldErrorOnExtraProperties = mapping.closed.option().getOrElse(true) // default behaviour is to error out
+    if (shouldErrorOnExtraProperties) checkNodeForAdditionalKeys(finalId, mapping.id, astMap.map, mapping, astMap, rootNode, additionalKey)
     node
   }
 

--- a/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/dialects/NodeMappingEmitter.scala
+++ b/amf-aml/shared/src/main/scala/amf/aml/internal/render/emitters/dialects/NodeMappingEmitter.scala
@@ -35,7 +35,7 @@ case class NodeMappingEmitter(
     } else {
       nodeMappable match {
         case nodeMapping: NodeMapping           => emitSingleNode(b, nodeMapping)
-        case unionNodeMapping: UnionNodeMapping => emitUnioNode(b, unionNodeMapping)
+        case unionNodeMapping: UnionNodeMapping => emitUnionNode(b, unionNodeMapping)
         case _                                  => // ignore
       }
     }
@@ -75,6 +75,10 @@ case class NodeMappingEmitter(
               })
             }
           }
+
+          nodeMapping.closed.option().foreach { additionalProps =>
+            b.entry("additionalProperties", !additionalProps)
+          }
           nodeMapping.idTemplate.option().foreach { idTemplate =>
             b.entry("idTemplate", idTemplate)
           }
@@ -85,7 +89,7 @@ case class NodeMappingEmitter(
     )
   }
 
-  protected def emitUnioNode(b: EntryBuilder, unionNodeMapping: UnionNodeMapping): Unit = {
+  protected def emitUnionNode(b: EntryBuilder, unionNodeMapping: UnionNodeMapping): Unit = {
     b.entry(
         unionNodeMapping.name.value(),
         _.obj { b =>

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.cycled.jsonld.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.cycled.jsonld.yaml
@@ -1,0 +1,16 @@
+#%Dialect 1.0
+dialect: Mapping Additional properties
+version: "1.0"
+documents:
+  root:
+    encodes: "#/declarations/Person"
+nodeMappings:
+  Person:
+    mapping:
+      name:
+        range: string
+      surname:
+        range: string
+      email:
+        range: string
+    additionalProperties: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.cycled.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.cycled.yaml
@@ -1,0 +1,16 @@
+#%Dialect 1.0
+dialect: Mapping Additional properties
+version: "1.0"
+documents:
+  root:
+    encodes: Person
+nodeMappings:
+  Person:
+    mapping:
+      name:
+        range: string
+      surname:
+        range: string
+      email:
+        range: string
+    additionalProperties: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.expanded.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.expanded.jsonld
@@ -1,0 +1,517 @@
+[
+  {
+    "@id": "",
+    "@type": [
+      "meta:Dialect",
+      "doc:Document",
+      "doc:Fragment",
+      "doc:Module",
+      "doc:Unit"
+    ],
+    "core:name": [
+      {
+        "@value": "Mapping Additional properties"
+      }
+    ],
+    "core:version": [
+      {
+        "@value": "1.0"
+      }
+    ],
+    "meta:documents": [
+      {
+        "@id": "/documents",
+        "@type": [
+          "meta:DocumentsModel",
+          "doc:DomainElement"
+        ],
+        "meta:rootDocument": [
+          {
+            "@id": "#/documents/root",
+            "@type": [
+              "meta:DocumentMapping",
+              "doc:DomainElement"
+            ],
+            "core:name": [
+              {
+                "@value": "Mapping Additional properties 1.0"
+              }
+            ],
+            "meta:encodedNode": [
+              {
+                "@id": "#/declarations/Person"
+              }
+            ],
+            "sourcemaps:sources": [
+              {
+                "@id": "#/documents/root/source-map",
+                "@type": [
+                  "sourcemaps:SourceMap"
+                ],
+                "sourcemaps:lexical": [
+                  {
+                    "@id": "#/documents/root/source-map/lexical/element_1",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/documents/root"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(6,7)-(9,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "#/documents/root/source-map/lexical/element_0",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "meta:encodedNode"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(7,4)-(9,0)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "sourcemaps:sources": [
+          {
+            "@id": "/documents#/source-map",
+            "@type": [
+              "sourcemaps:SourceMap"
+            ],
+            "sourcemaps:lexical": [
+              {
+                "@id": "/documents#/source-map/lexical/element_1",
+                "sourcemaps:element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml/documents"
+                  }
+                ],
+                "sourcemaps:value": [
+                  {
+                    "@value": "[(6,0)-(9,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "/documents#/source-map/lexical/element_0",
+                "sourcemaps:element": [
+                  {
+                    "@value": "meta:rootDocument"
+                  }
+                ],
+                "sourcemaps:value": [
+                  {
+                    "@value": "[(6,2)-(9,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:location": [
+      {
+        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml"
+      }
+    ],
+    "doc:root": [
+      {
+        "@value": true
+      }
+    ],
+    "doc:processingData": [
+      {
+        "@id": "#/BaseUnitProcessingData",
+        "@type": [
+          "doc:BaseUnitProcessingData"
+        ],
+        "doc:transformed": [
+          {
+            "@value": false
+          }
+        ],
+        "doc:sourceSpec": [
+          {
+            "@value": "AML 1.0"
+          }
+        ]
+      }
+    ],
+    "sourcemaps:sources": [
+      {
+        "@id": "#/source-map",
+        "@type": [
+          "sourcemaps:SourceMap"
+        ],
+        "sourcemaps:lexical": [
+          {
+            "@id": "#/source-map/lexical/element_3",
+            "sourcemaps:element": [
+              {
+                "@value": "core:version"
+              }
+            ],
+            "sourcemaps:value": [
+              {
+                "@value": "[(3,0)-(5,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "#/source-map/lexical/element_1",
+            "sourcemaps:element": [
+              {
+                "@value": "core:name"
+              }
+            ],
+            "sourcemaps:value": [
+              {
+                "@value": "[(2,0)-(3,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "#/source-map/lexical/element_0",
+            "sourcemaps:element": [
+              {
+                "@value": "meta:documents"
+              }
+            ],
+            "sourcemaps:value": [
+              {
+                "@value": "[(5,0)-(9,0)]"
+              }
+            ]
+          },
+          {
+            "@id": "#/source-map/lexical/element_2",
+            "sourcemaps:element": [
+              {
+                "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml"
+              }
+            ],
+            "sourcemaps:value": [
+              {
+                "@value": "[(2,0)-(19,0)]"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "doc:declares": [
+      {
+        "@id": "#/declarations/Person",
+        "@type": [
+          "meta:NodeMapping",
+          "shacl:Shape",
+          "doc:DomainElement"
+        ],
+        "core:name": [
+          {
+            "@value": "Person"
+          }
+        ],
+        "shacl:property": [
+          {
+            "@id": "#/declarations/Person/property/surname",
+            "@type": [
+              "meta:NodePropertyMapping",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#surname"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "surname"
+              }
+            ],
+            "shacl:datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "sourcemaps:sources": [
+              {
+                "@id": "#/declarations/Person/property/surname/source-map",
+                "@type": [
+                  "sourcemaps:SourceMap"
+                ],
+                "sourcemaps:lexical": [
+                  {
+                    "@id": "#/declarations/Person/property/surname/source-map/lexical/element_2",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "core:name"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(14,6)-(14,13)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "#/declarations/Person/property/surname/source-map/lexical/element_0",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "shacl:datatype"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(15,8)-(16,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "#/declarations/Person/property/surname/source-map/lexical/element_1",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person/property/surname"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(14,14)-(16,0)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "#/declarations/Person/property/name",
+            "@type": [
+              "meta:NodePropertyMapping",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#name"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "name"
+              }
+            ],
+            "shacl:datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "sourcemaps:sources": [
+              {
+                "@id": "#/declarations/Person/property/name/source-map",
+                "@type": [
+                  "sourcemaps:SourceMap"
+                ],
+                "sourcemaps:lexical": [
+                  {
+                    "@id": "#/declarations/Person/property/name/source-map/lexical/element_2",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "core:name"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(12,6)-(12,10)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "#/declarations/Person/property/name/source-map/lexical/element_0",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "shacl:datatype"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(13,8)-(14,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "#/declarations/Person/property/name/source-map/lexical/element_1",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person/property/name"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(12,11)-(14,0)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "@id": "#/declarations/Person/property/email",
+            "@type": [
+              "meta:NodePropertyMapping",
+              "doc:DomainElement"
+            ],
+            "shacl:path": [
+              {
+                "@id": "http://a.ml/vocabularies/data#email"
+              }
+            ],
+            "core:name": [
+              {
+                "@value": "email"
+              }
+            ],
+            "shacl:datatype": [
+              {
+                "@id": "http://www.w3.org/2001/XMLSchema#string"
+              }
+            ],
+            "sourcemaps:sources": [
+              {
+                "@id": "#/declarations/Person/property/email/source-map",
+                "@type": [
+                  "sourcemaps:SourceMap"
+                ],
+                "sourcemaps:lexical": [
+                  {
+                    "@id": "#/declarations/Person/property/email/source-map/lexical/element_2",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "core:name"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(16,6)-(16,11)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "#/declarations/Person/property/email/source-map/lexical/element_0",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "shacl:datatype"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(17,8)-(18,0)]"
+                      }
+                    ]
+                  },
+                  {
+                    "@id": "#/declarations/Person/property/email/source-map/lexical/element_1",
+                    "sourcemaps:element": [
+                      {
+                        "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person/property/email"
+                      }
+                    ],
+                    "sourcemaps:value": [
+                      {
+                        "@value": "[(16,12)-(18,0)]"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "shacl:closed": [
+          {
+            "@value": false
+          }
+        ],
+        "sourcemaps:sources": [
+          {
+            "@id": "#/declarations/Person/source-map",
+            "@type": [
+              "sourcemaps:SourceMap"
+            ],
+            "sourcemaps:lexical": [
+              {
+                "@id": "#/declarations/Person/source-map/lexical/element_3",
+                "sourcemaps:element": [
+                  {
+                    "@value": "shacl:property"
+                  }
+                ],
+                "sourcemaps:value": [
+                  {
+                    "@value": "[(11,4)-(18,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "#/declarations/Person/source-map/lexical/element_1",
+                "sourcemaps:element": [
+                  {
+                    "@value": "core:name"
+                  }
+                ],
+                "sourcemaps:value": [
+                  {
+                    "@value": "[(10,2)-(10,8)]"
+                  }
+                ]
+              },
+              {
+                "@id": "#/declarations/Person/source-map/lexical/element_0",
+                "sourcemaps:element": [
+                  {
+                    "@value": "shacl:closed"
+                  }
+                ],
+                "sourcemaps:value": [
+                  {
+                    "@value": "[(18,4)-(19,0)]"
+                  }
+                ]
+              },
+              {
+                "@id": "#/declarations/Person/source-map/lexical/element_2",
+                "sourcemaps:element": [
+                  {
+                    "@value": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person"
+                  }
+                ],
+                "sourcemaps:value": [
+                  {
+                    "@value": "[(10,2)-(19,0)]"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "@context": {
+      "@base": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml",
+      "shacl": "http://www.w3.org/ns/shacl#",
+      "doc": "http://a.ml/vocabularies/document#",
+      "core": "http://a.ml/vocabularies/core#",
+      "sourcemaps": "http://a.ml/vocabularies/document-source-maps#",
+      "meta": "http://a.ml/vocabularies/meta#"
+    }
+  }
+]

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.flattened.jsonld
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.flattened.jsonld
@@ -1,0 +1,402 @@
+{
+  "@graph": [
+    {
+      "@id": "#/BaseUnitProcessingData",
+      "@type": [
+        "doc:BaseUnitProcessingData"
+      ],
+      "doc:transformed": false,
+      "doc:sourceSpec": "AML 1.0"
+    },
+    {
+      "@id": "/documents",
+      "@type": [
+        "meta:DocumentsModel",
+        "doc:DomainElement"
+      ],
+      "meta:rootDocument": {
+        "@id": "#/documents/root"
+      },
+      "sourcemaps:sources": [
+        {
+          "@id": "/documents#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "#/documents/root",
+      "@type": [
+        "meta:DocumentMapping",
+        "doc:DomainElement"
+      ],
+      "core:name": "Mapping Additional properties 1.0",
+      "meta:encodedNode": [
+        {
+          "@id": "#/declarations/Person"
+        }
+      ],
+      "sourcemaps:sources": [
+        {
+          "@id": "#/documents/root/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "/documents#/source-map",
+      "@type": [
+        "sourcemaps:SourceMap"
+      ],
+      "sourcemaps:lexical": [
+        {
+          "@id": "/documents#/source-map/lexical/element_1"
+        },
+        {
+          "@id": "/documents#/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "#/documents/root/source-map",
+      "@type": [
+        "sourcemaps:SourceMap"
+      ],
+      "sourcemaps:lexical": [
+        {
+          "@id": "#/documents/root/source-map/lexical/element_1"
+        },
+        {
+          "@id": "#/documents/root/source-map/lexical/element_0"
+        }
+      ]
+    },
+    {
+      "@id": "/documents#/source-map/lexical/element_1",
+      "sourcemaps:element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml/documents",
+      "sourcemaps:value": "[(6,0)-(9,0)]"
+    },
+    {
+      "@id": "/documents#/source-map/lexical/element_0",
+      "sourcemaps:element": "meta:rootDocument",
+      "sourcemaps:value": "[(6,2)-(9,0)]"
+    },
+    {
+      "@id": "#/documents/root/source-map/lexical/element_1",
+      "sourcemaps:element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/documents/root",
+      "sourcemaps:value": "[(6,7)-(9,0)]"
+    },
+    {
+      "@id": "#/documents/root/source-map/lexical/element_0",
+      "sourcemaps:element": "meta:encodedNode",
+      "sourcemaps:value": "[(7,4)-(9,0)]"
+    },
+    {
+      "@id": "",
+      "doc:declares": [
+        {
+          "@id": "#/declarations/Person"
+        }
+      ],
+      "@type": [
+        "meta:Dialect",
+        "doc:Document",
+        "doc:Fragment",
+        "doc:Module",
+        "doc:Unit"
+      ],
+      "core:name": "Mapping Additional properties",
+      "core:version": "1.0",
+      "meta:documents": {
+        "@id": "/documents"
+      },
+      "doc:location": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml",
+      "doc:root": true,
+      "doc:processingData": {
+        "@id": "#/BaseUnitProcessingData"
+      },
+      "sourcemaps:sources": [
+        {
+          "@id": "#/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person",
+      "@type": [
+        "meta:NodeMapping",
+        "shacl:Shape",
+        "doc:DomainElement"
+      ],
+      "core:name": "Person",
+      "shacl:property": [
+        {
+          "@id": "#/declarations/Person/property/surname"
+        },
+        {
+          "@id": "#/declarations/Person/property/name"
+        },
+        {
+          "@id": "#/declarations/Person/property/email"
+        }
+      ],
+      "shacl:closed": false,
+      "sourcemaps:sources": [
+        {
+          "@id": "#/declarations/Person/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "#/source-map",
+      "@type": [
+        "sourcemaps:SourceMap"
+      ],
+      "sourcemaps:lexical": [
+        {
+          "@id": "#/source-map/lexical/element_3"
+        },
+        {
+          "@id": "#/source-map/lexical/element_1"
+        },
+        {
+          "@id": "#/source-map/lexical/element_0"
+        },
+        {
+          "@id": "#/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person/property/surname",
+      "@type": [
+        "meta:NodePropertyMapping",
+        "doc:DomainElement"
+      ],
+      "shacl:path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#surname"
+        }
+      ],
+      "core:name": "surname",
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "sourcemaps:sources": [
+        {
+          "@id": "#/declarations/Person/property/surname/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person/property/name",
+      "@type": [
+        "meta:NodePropertyMapping",
+        "doc:DomainElement"
+      ],
+      "shacl:path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#name"
+        }
+      ],
+      "core:name": "name",
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "sourcemaps:sources": [
+        {
+          "@id": "#/declarations/Person/property/name/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person/property/email",
+      "@type": [
+        "meta:NodePropertyMapping",
+        "doc:DomainElement"
+      ],
+      "shacl:path": [
+        {
+          "@id": "http://a.ml/vocabularies/data#email"
+        }
+      ],
+      "core:name": "email",
+      "shacl:datatype": [
+        {
+          "@id": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ],
+      "sourcemaps:sources": [
+        {
+          "@id": "#/declarations/Person/property/email/source-map"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person/source-map",
+      "@type": [
+        "sourcemaps:SourceMap"
+      ],
+      "sourcemaps:lexical": [
+        {
+          "@id": "#/declarations/Person/source-map/lexical/element_3"
+        },
+        {
+          "@id": "#/declarations/Person/source-map/lexical/element_1"
+        },
+        {
+          "@id": "#/declarations/Person/source-map/lexical/element_0"
+        },
+        {
+          "@id": "#/declarations/Person/source-map/lexical/element_2"
+        }
+      ]
+    },
+    {
+      "@id": "#/source-map/lexical/element_3",
+      "sourcemaps:element": "core:version",
+      "sourcemaps:value": "[(3,0)-(5,0)]"
+    },
+    {
+      "@id": "#/source-map/lexical/element_1",
+      "sourcemaps:element": "core:name",
+      "sourcemaps:value": "[(2,0)-(3,0)]"
+    },
+    {
+      "@id": "#/source-map/lexical/element_0",
+      "sourcemaps:element": "meta:documents",
+      "sourcemaps:value": "[(5,0)-(9,0)]"
+    },
+    {
+      "@id": "#/source-map/lexical/element_2",
+      "sourcemaps:element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml",
+      "sourcemaps:value": "[(2,0)-(19,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/surname/source-map",
+      "@type": [
+        "sourcemaps:SourceMap"
+      ],
+      "sourcemaps:lexical": [
+        {
+          "@id": "#/declarations/Person/property/surname/source-map/lexical/element_2"
+        },
+        {
+          "@id": "#/declarations/Person/property/surname/source-map/lexical/element_0"
+        },
+        {
+          "@id": "#/declarations/Person/property/surname/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person/property/name/source-map",
+      "@type": [
+        "sourcemaps:SourceMap"
+      ],
+      "sourcemaps:lexical": [
+        {
+          "@id": "#/declarations/Person/property/name/source-map/lexical/element_2"
+        },
+        {
+          "@id": "#/declarations/Person/property/name/source-map/lexical/element_0"
+        },
+        {
+          "@id": "#/declarations/Person/property/name/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person/property/email/source-map",
+      "@type": [
+        "sourcemaps:SourceMap"
+      ],
+      "sourcemaps:lexical": [
+        {
+          "@id": "#/declarations/Person/property/email/source-map/lexical/element_2"
+        },
+        {
+          "@id": "#/declarations/Person/property/email/source-map/lexical/element_0"
+        },
+        {
+          "@id": "#/declarations/Person/property/email/source-map/lexical/element_1"
+        }
+      ]
+    },
+    {
+      "@id": "#/declarations/Person/source-map/lexical/element_3",
+      "sourcemaps:element": "shacl:property",
+      "sourcemaps:value": "[(11,4)-(18,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/source-map/lexical/element_1",
+      "sourcemaps:element": "core:name",
+      "sourcemaps:value": "[(10,2)-(10,8)]"
+    },
+    {
+      "@id": "#/declarations/Person/source-map/lexical/element_0",
+      "sourcemaps:element": "shacl:closed",
+      "sourcemaps:value": "[(18,4)-(19,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/source-map/lexical/element_2",
+      "sourcemaps:element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person",
+      "sourcemaps:value": "[(10,2)-(19,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/surname/source-map/lexical/element_2",
+      "sourcemaps:element": "core:name",
+      "sourcemaps:value": "[(14,6)-(14,13)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/surname/source-map/lexical/element_0",
+      "sourcemaps:element": "shacl:datatype",
+      "sourcemaps:value": "[(15,8)-(16,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/surname/source-map/lexical/element_1",
+      "sourcemaps:element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person/property/surname",
+      "sourcemaps:value": "[(14,14)-(16,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/name/source-map/lexical/element_2",
+      "sourcemaps:element": "core:name",
+      "sourcemaps:value": "[(12,6)-(12,10)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/name/source-map/lexical/element_0",
+      "sourcemaps:element": "shacl:datatype",
+      "sourcemaps:value": "[(13,8)-(14,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/name/source-map/lexical/element_1",
+      "sourcemaps:element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person/property/name",
+      "sourcemaps:value": "[(12,11)-(14,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/email/source-map/lexical/element_2",
+      "sourcemaps:element": "core:name",
+      "sourcemaps:value": "[(16,6)-(16,11)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/email/source-map/lexical/element_0",
+      "sourcemaps:element": "shacl:datatype",
+      "sourcemaps:value": "[(17,8)-(18,0)]"
+    },
+    {
+      "@id": "#/declarations/Person/property/email/source-map/lexical/element_1",
+      "sourcemaps:element": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml#/declarations/Person/property/email",
+      "sourcemaps:value": "[(16,12)-(18,0)]"
+    }
+  ],
+  "@context": {
+    "@base": "file://amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml",
+    "shacl": "http://www.w3.org/ns/shacl#",
+    "doc": "http://a.ml/vocabularies/document#",
+    "core": "http://a.ml/vocabularies/core#",
+    "sourcemaps": "http://a.ml/vocabularies/document-source-maps#",
+    "meta": "http://a.ml/vocabularies/meta#"
+  }
+}

--- a/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/dialects/additional-properties/dialect.yaml
@@ -1,0 +1,18 @@
+#%Dialect 1.0
+dialect: Mapping Additional properties
+version: 1.0
+
+documents:
+  root:
+    encodes: Person
+
+nodeMappings:
+  Person:
+    mapping:
+      name:
+        range: string
+      surname:
+        range: string
+      email:
+        range: string
+    additionalProperties: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/dialect.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/dialect.yaml
@@ -1,0 +1,23 @@
+#%Dialect 1.0
+dialect: Mapping Additional properties
+version: 1.0
+
+documents:
+  root:
+    encodes: Person
+
+nodeMappings:
+  Person:
+    mapping:
+      name:
+        range: PersonName
+      club:
+        range: string
+
+  PersonName:
+    mapping:
+      name:
+        range: string
+      surname:
+        range: string
+    additionalProperties: true

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/instance.yaml
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/instance.yaml
@@ -1,0 +1,7 @@
+#%Mapping Additional properties 1.0
+name:
+  name: Lionel
+  surname: Messi
+  nickname: Pulga
+club: PSG
+number: 30

--- a/amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/report.json
+++ b/amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/report.json
@@ -1,0 +1,32 @@
+{
+  "@type": "http://www.w3.org/ns/shacl#ValidationReport",
+  "http://www.w3.org/ns/shacl#conforms": false,
+  "http://www.w3.org/ns/shacl#result": [
+    {
+      "@type": "http://www.w3.org/ns/shacl#ValidationResult",
+      "http://www.w3.org/ns/shacl#resultSeverity": {
+        "@id": "http://www.w3.org/ns/shacl#Violation"
+      },
+      "http://www.w3.org/ns/shacl#focusNode": {
+        "@id": "file://amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/instance.yaml#/encodes"
+      },
+      "http://www.w3.org/ns/shacl#resultMessage": "Property: 'number' not supported in a file://amf-aml/shared/src/test/resources/vocabularies2/instances/additional-properties/dialect.yaml#/declarations/Person node",
+      "http://www.w3.org/ns/shacl#sourceShape": {
+        "@id": "http://a.ml/vocabularies/amf/aml#closed-shape"
+      },
+      "http://a.ml/vocabularies/amf/parser#lexicalPosition": {
+        "@type": "http://a.ml/vocabularies/amf/parser#Position",
+        "http://a.ml/vocabularies/amf/parser#start": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 7,
+          "http://a.ml/vocabularies/amf/parser#column": 8
+        },
+        "http://a.ml/vocabularies/amf/parser#end": {
+          "@type": "http://a.ml/vocabularies/amf/parser#Location",
+          "http://a.ml/vocabularies/amf/parser#line": 7,
+          "http://a.ml/vocabularies/amf/parser#column": 10
+        }
+      }
+    }
+  ]
+}

--- a/amf-aml/shared/src/test/scala/amf/testing/parsing/DialectsParsingTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/parsing/DialectsParsingTest.scala
@@ -349,31 +349,31 @@ trait DialectsParsingTest extends DialectTests {
 
   test("Parse dialect with $id directive") {
     cycle(
-      "dialect.yaml",
-      "dialect.jsonld",
-      Some(Mimes.`application/ld+json`),
-      AMLConfiguration.predefined().withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris),
-      directory = s"$basePath/id-directive"
+        "dialect.yaml",
+        "dialect.jsonld",
+        Some(Mimes.`application/ld+json`),
+        AMLConfiguration.predefined().withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris),
+        directory = s"$basePath/id-directive"
     )
   }
 
   test("Parse dialect library with $id directive") {
     cycle(
-      "dialect.yaml",
-      "dialect.jsonld",
-      Some(Mimes.`application/ld+json`),
-      AMLConfiguration.predefined().withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris),
-      directory = s"$basePath/id-directive-library"
+        "dialect.yaml",
+        "dialect.jsonld",
+        Some(Mimes.`application/ld+json`),
+        AMLConfiguration.predefined().withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris),
+        directory = s"$basePath/id-directive-library"
     )
   }
 
   test("Parse dialect fragment with $id directive") {
     cycle(
-      "dialect.yaml",
-      "dialect.jsonld",
-      Some(Mimes.`application/ld+json`),
-      AMLConfiguration.predefined().withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris),
-      directory = s"$basePath/id-directive-fragment"
+        "dialect.yaml",
+        "dialect.jsonld",
+        Some(Mimes.`application/ld+json`),
+        AMLConfiguration.predefined().withRenderOptions(RenderOptions().withPrettyPrint.withCompactUris),
+        directory = s"$basePath/id-directive-fragment"
     )
   }
 
@@ -423,5 +423,29 @@ trait DialectsParsingTest extends DialectTests {
           "dialect.cycled.yaml",
           mediaType = Some(Mimes.`application/yaml`),
           directory = s"$basePath/default-facet")
+  }
+
+  multiGoldenTest("Additional properties facet parsing", "dialect.%s") { config =>
+    cycle(
+        "dialect.yaml",
+        config.golden,
+        Some(Mimes.`application/ld+json`),
+        AMLConfiguration.predefined().withRenderOptions(config.renderOptions.withCompactUris),
+        directory = s"$basePath/additional-properties"
+    )
+  }
+
+  multiSourceTest("Render additional properties facet from JSON-LD", "dialect.%s") { config =>
+    cycle(config.source,
+          "dialect.cycled.jsonld.yaml",
+          mediaType = Some(Mimes.`application/yaml`),
+          directory = s"$basePath/additional-properties")
+  }
+
+  test("Render additional properties facet from YAML") {
+    cycle("dialect.yaml",
+          "dialect.cycled.yaml",
+          Some(Mimes.`application/yaml`),
+          directory = s"$basePath/additional-properties")
   }
 }

--- a/amf-aml/shared/src/test/scala/amf/testing/validation/DialectDefinitionValidationTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/validation/DialectDefinitionValidationTest.scala
@@ -68,7 +68,8 @@ class DialectDefinitionValidationTest extends AsyncFunSuite with Matchers with D
   }
 
   test("Test nested eventual ambiguity in property") {
-    validate("/nested-eventual-ambiguity-property/dialect.yaml", Some("nested-eventual-ambiguity-property/report.json"))
+    validate("/nested-eventual-ambiguity-property/dialect.yaml",
+             Some("nested-eventual-ambiguity-property/report.json"))
   }
 
   test("Test node mapping with reserved names") {
@@ -145,5 +146,9 @@ class DialectDefinitionValidationTest extends AsyncFunSuite with Matchers with D
 
   test("Dialect with property mapping with default key") {
     validate("../../../dialects/default-facet/dialect.yaml", None)
+  }
+
+  test("Dialect with NodeMapping with additional properties") {
+    validate("../../../dialects/additional-properties/dialect.yaml", None)
   }
 }

--- a/amf-aml/shared/src/test/scala/amf/testing/validation/DialectInstancesValidationTest.scala
+++ b/amf-aml/shared/src/test/scala/amf/testing/validation/DialectInstancesValidationTest.scala
@@ -239,4 +239,8 @@ trait DialectInstancesValidationTest extends DialectInstanceValidation {
         path = s"$instancesPath/json-root-union/"
     )
   }
+
+  test("One node should validate check for additional props and another shouldn't") {
+    validate("dialect.yaml", "instance.yaml", Some("report.json"), path = s"$instancesPath/additional-properties/")
+  }
 }


### PR DESCRIPTION
Related to: https://github.com/aml-org/amf-core/pull/441

Comments in aml-org/amf#1339:

How would or should additionalProperties behave for a UnionShape ?
- Should the UnionShape have the "additionalProperties"? If one of the component also has "additionalProperties", should the union override it ?
- Should the parsing depend on wether a component of the union has the "additionalProperties" ?