### PR TITLE
Publish 6.2.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,6 @@ pipeline {
                 anyOf {
                     branch 'master'
                     branch 'develop'
-                    branch 'release/*'
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
                 anyOf {
                     branch 'master'
                     branch 'develop'
+                    branch 'release/*'
                 }
             }
             steps {

--- a/amf-rdf/shared/src/main/scala/amf/rdf/internal/RdfModelEmitter.scala
+++ b/amf-rdf/shared/src/main/scala/amf/rdf/internal/RdfModelEmitter.scala
@@ -58,11 +58,11 @@ class RdfModelEmitter(rdfModel: RdfModel, fieldProvision: ApplicableMetaFieldRen
         val modelFields = fieldProvision.fieldsFor(element, options) ++ (obj match {
           case _: ShapeModel =>
             Seq(
-              ShapeModel.CustomShapePropertyDefinitions,
-              ShapeModel.CustomShapeProperties
+                ShapeModel.CustomShapePropertyDefinitions,
+                ShapeModel.CustomShapeProperties
             )
           case _ => Nil
-        }).filter(options.renderField)
+        })
 
         element match {
           case e: ObjectNode if options.isValidation =>

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val ivyLocal = Resolver.file("ivy", file(Path.userHome.absolutePath + "/.ivy2/lo
 
 name := "amf-aml"
 
-ThisBuild / version      := "6.2.3"
+ThisBuild / version      := "6.3.0-SNAPSHOT"
 ThisBuild / scalaVersion := "2.12.13"
 
 publish := {}
@@ -20,7 +20,7 @@ lazy val workspaceDirectory: File =
     case _       => Path.userHome / "mulesoft"
   }
 
-val amfCoreVersion = "5.2.3"
+val amfCoreVersion = "5.3.0-SNAPSHOT"
 
 lazy val amfCoreJVMRef = ProjectRef(workspaceDirectory / "amf-core", "coreJVM")
 lazy val amfCoreJSRef  = ProjectRef(workspaceDirectory / "amf-core", "coreJS")

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val ivyLocal = Resolver.file("ivy", file(Path.userHome.absolutePath + "/.ivy2/lo
 
 name := "amf-aml"
 
-ThisBuild / version      := "6.2.4-RC.0"
+ThisBuild / version      := "6.2.4"
 ThisBuild / scalaVersion := "2.12.13"
 
 publish := {}
@@ -20,7 +20,7 @@ lazy val workspaceDirectory: File =
     case _       => Path.userHome / "mulesoft"
   }
 
-val amfCoreVersion = "5.2.4-RC.0"
+val amfCoreVersion = "5.2.4"
 
 lazy val amfCoreJVMRef = ProjectRef(workspaceDirectory / "amf-core", "coreJVM")
 lazy val amfCoreJSRef  = ProjectRef(workspaceDirectory / "amf-core", "coreJS")

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val ivyLocal = Resolver.file("ivy", file(Path.userHome.absolutePath + "/.ivy2/lo
 
 name := "amf-aml"
 
-ThisBuild / version      := "6.3.0-SNAPSHOT"
+ThisBuild / version      := "6.2.4-RC.0"
 ThisBuild / scalaVersion := "2.12.13"
 
 publish := {}
@@ -20,7 +20,7 @@ lazy val workspaceDirectory: File =
     case _       => Path.userHome / "mulesoft"
   }
 
-val amfCoreVersion = "5.3.0-SNAPSHOT"
+val amfCoreVersion = "5.2.4-RC.0"
 
 lazy val amfCoreJVMRef = ProjectRef(workspaceDirectory / "amf-core", "coreJVM")
 lazy val amfCoreJSRef  = ProjectRef(workspaceDirectory / "amf-core", "coreJS")


### PR DESCRIPTION
- Back to 6.3.0-SNAPSHOT
- (fix): removed fitlerFields usage as it wasn't configured anywhere in AMF
- Freeze and publis 6.2.4-RC.0
- Publish 6.2.4
